### PR TITLE
Facility Entity dynprop field for pt customization

### DIFF
--- a/src/Perpetuum/Keywords.cs
+++ b/src/Perpetuum/Keywords.cs
@@ -366,6 +366,7 @@ namespace Perpetuum
         public const string extensionLevelRequired = "extensionLevelRequired";
         public const string extensionRemoveAllowed = "extensionRemoveAllowed";
         public const string extra = "extra";
+        public const string extrapoints = "extrapoints";
         public const string extractionType = "extractionType";
         public const string fails = "fails";
         public const string far = "far";

--- a/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
+++ b/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
@@ -50,7 +50,7 @@ namespace Perpetuum.Services.ProductionEngine.Facilities
             if (dockingbase is Outpost)
             {
                 ProductionFacility facility = (dockingbase as Outpost).GetProductionFacilities().Where(x => x.Eid == this.Eid).First();
-                int extrapts = facility.DynamicProperties.GetOrDefault<int>("extrapoints"); //Entity-property for unique facility base-proficiencies
+                int extrapts = facility.DynamicProperties.GetOrDefault<int>(k.extrapoints); //Entity-property for unique facility base-proficiencies
                 modifier = (Outpost.GetFacilityLevelFromStack(facility.Eid) + extrapts) * 25; //bonus per facility level
             }
             return modifier;

--- a/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
+++ b/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
@@ -42,7 +42,7 @@ namespace Perpetuum.Services.ProductionEngine.Facilities
         {
             return $"{ED.Name} {ED.Definition} {Eid}";
         }
-
+        
         private int GetFacilityBonus()
         {
             int modifier = 0;
@@ -50,7 +50,8 @@ namespace Perpetuum.Services.ProductionEngine.Facilities
             if (dockingbase is Outpost)
             {
                 ProductionFacility facility = (dockingbase as Outpost).GetProductionFacilities().Where(x => x.Eid == this.Eid).First();
-                modifier = Outpost.GetFacilityLevelFromStack(facility.Eid) * 25;
+                int extrapts = facility.DynamicProperties.GetOrDefault<int>("extrapoints"); //Entity-property for unique facility base-proficiencies
+                modifier = (Outpost.GetFacilityLevelFromStack(facility.Eid) + extrapts) * 25; //bonus per facility level
             }
             return modifier;
         }


### PR DESCRIPTION
Added field to be read in (if exists) to allow unique facility entities to have bonuses ontop of their entity default point configuration.