### PR TITLE
set homebase on trainingExit to chosen dockingbase (currently TMA)

### DIFF
--- a/src/Perpetuum/Zones/Teleporting/Strategies/TrainingExitStrategy.cs
+++ b/src/Perpetuum/Zones/Teleporting/Strategies/TrainingExitStrategy.cs
@@ -79,6 +79,8 @@ namespace Perpetuum.Zones.Teleporting.Strategies
             var dockingBase = hardCodeTMACorp.GetDockingBase();
             dockingBase.CreateStarterRobotForCharacter(character, true);
             dockingBase.DockIn(character, TimeSpan.Zero, ZoneExitType.TrainingExitTeleport);
+            //Set Home Base of character to Docked base
+            character.HomeBaseEid = dockingBase.Eid;
 
             var publicContainer = dockingBase.GetPublicContainerWithItems(character);
             CreateRewardItems(character, publicContainer);


### PR DESCRIPTION
This is how CharacterSetHomeBase request handler does it too.

Closes: https://github.com/OpenPerpetuum/OP-Project/issues/91