### PR TITLE
Probes: Bug fixes on despawn

### DIFF
--- a/src/Perpetuum/Units/UnitDespawnHelper.cs
+++ b/src/Perpetuum/Units/UnitDespawnHelper.cs
@@ -6,6 +6,7 @@ using Perpetuum.Zones.Effects;
 namespace Perpetuum.Units
 {
     public delegate bool UnitDespawnerCanApplyEffect(Unit unit);
+    public delegate void UnitDespawnStrategy(Unit unit);
 
     public class UnitDespawnHelper 
     {
@@ -19,6 +20,8 @@ namespace Perpetuum.Units
 
         public UnitDespawnerCanApplyEffect CanApplyDespawnEffect { private get; set; }
 
+        public UnitDespawnStrategy DespawnStrategy { private get; set; }
+
         public void Update(TimeSpan time,Unit unit)
         {
             _timer.Update(time).IsPassed(() =>
@@ -29,9 +32,15 @@ namespace Perpetuum.Units
                     return;
 
                 CanApplyDespawnEffect = null;
-
-                unit.States.Teleport = true; //kis villam visual amikor kiszedi
-                unit.RemoveFromZone();
+                if (DespawnStrategy != null)
+                {
+                    DespawnStrategy(unit);
+                }
+                else
+                {
+                    unit.States.Teleport = true; //kis villam visual amikor kiszedi
+                    unit.RemoveFromZone();
+                }
             });
         }
 

--- a/src/Perpetuum/Zones/ProximityProbes/ProximityProbe.cs
+++ b/src/Perpetuum/Zones/ProximityProbes/ProximityProbe.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Perpetuum.Accounting.Characters;
-using Perpetuum.Data;
 using Perpetuum.EntityFramework;
 using Perpetuum.ExportedTypes;
 using Perpetuum.Groups.Corporations;

--- a/src/Perpetuum/Zones/ProximityProbes/ProximityProbe.cs
+++ b/src/Perpetuum/Zones/ProximityProbes/ProximityProbe.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Perpetuum.Accounting.Characters;
+using Perpetuum.Data;
 using Perpetuum.EntityFramework;
 using Perpetuum.ExportedTypes;
 using Perpetuum.Groups.Corporations;
@@ -45,6 +46,7 @@ namespace Perpetuum.Zones.ProximityProbes
         public void SetDespawnTime(TimeSpan despawnTime)
         {
             _despawnHelper = UnitDespawnHelper.Create(this, despawnTime);
+            _despawnHelper.DespawnStrategy = Kill;
         }
 
         protected internal override void UpdatePlayerVisibility(Player player)
@@ -76,6 +78,13 @@ namespace Perpetuum.Zones.ProximityProbes
 
                 //do something
                 OnUnitsFound(robotsNearMe);
+            }
+
+            if (_despawnHelper == null)
+            {
+                var m = GetPropertyModifier(AggregateField.despawn_time);
+                var timespan = TimeSpan.FromMilliseconds((int)m.Value);
+                SetDespawnTime(timespan);
             }
 
             _despawnHelper.Update(time, this);
@@ -119,11 +128,8 @@ namespace Perpetuum.Zones.ProximityProbes
         {
             //uccso info a regisztraltaknak
             SendProbeDead();
-
             PBSRegisterHelper.ClearMembersFromSql(Eid);
-
             Zone.UnitService.RemoveUserUnit(this);
-            
             Logger.Info("probe got deleted " + Eid);
         }
         


### PR DESCRIPTION
DespawnHelper was null after server restart (init'd on constructor, lives in cache)
DespawnHelper removeFromZone procedure did not play nice with probe's OnProbeDead cleanup.  Force-kill probe on despawn.
Now provides notification on death and despawn.  Properly cleans up object.