### PR TITLE
Artifact random fix

### DIFF
--- a/src/Perpetuum/Zones/Artifacts/Generators/Loot/ArtifactLootGenerator.cs
+++ b/src/Perpetuum/Zones/Artifacts/Generators/Loot/ArtifactLootGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Perpetuum.Services.Looting;
@@ -8,10 +9,12 @@ namespace Perpetuum.Zones.Artifacts.Generators.Loot
     public class ArtifactLootGenerator : IArtifactLootGenerator
     {
         private readonly IArtifactRepository _artifactRepository;
+        private Random _random;
 
         public ArtifactLootGenerator(IArtifactRepository artifactRepository)
         {
             _artifactRepository = artifactRepository;
+            _random = new Random();
         }
 
         public ArtifactLootItems GenerateLoot(Artifact artifact)
@@ -32,7 +35,8 @@ namespace Perpetuum.Zones.Artifacts.Generators.Loot
             {
                 foreach (var loot in loots)
                 {
-                    var chance = FastRandom.NextDouble();
+                    var chance = _random.NextDouble();
+
                     if (chance > loot.Chance)
                         continue;
 


### PR DESCRIPTION
We don't trust the random behavior of Fastrandom over short timespans or on some systems because of system specific behavior.

Artifact.GenerateLoot is called on popping an artifact, so it *is* time sensitive.
But where we see FastRandom roll the same numbers in a tight loop, maybe we take the performance hit on calling system.Random.

