### PR TITLE
Ep curve v3 - linear with 25x hold

### DIFF
--- a/src/Perpetuum/Accounting/AccountManager.cs
+++ b/src/Perpetuum/Accounting/AccountManager.cs
@@ -106,7 +106,6 @@ namespace Perpetuum.Accounting
         }
 
         private const double BOOSTMULTIPLIERMAX = 25;
-        private const double BOOSTEXPONENT = 0.75;
         private const double SERVER_DESIRED_EP_LEVEL = 750000;
 
         public IDictionary<string,object> GetEPData(Account account,Character character)
@@ -146,10 +145,10 @@ namespace Perpetuum.Accounting
             return ((BOOSTMULTIPLIERMAX - 1) * boostFactor) + bonusIncrease + itemIncrease;
         }
 
-        private static double GetExperienceBoostingFactor(int collectedEpSum,double epLevelThreshold)
+        private static double GetExperienceBoostingFactor(int collectedEpSum, double epLevelThreshold)
         {
             var linearRatio = collectedEpSum / epLevelThreshold;
-            var result = 1.0 - (Math.Pow(linearRatio,BOOSTEXPONENT));
+            var result = 1.0 - linearRatio;
             result = result.Clamp();
 
             return result;

--- a/src/Perpetuum/Accounting/AccountManager.cs
+++ b/src/Perpetuum/Accounting/AccountManager.cs
@@ -107,6 +107,7 @@ namespace Perpetuum.Accounting
 
         private const double BOOSTMULTIPLIERMAX = 25;
         private const double SERVER_DESIRED_EP_LEVEL = 750000;
+        private const double GAURANTEED_BOOST_MAX_THRESH = 45000;
 
         public IDictionary<string,object> GetEPData(Account account,Character character)
         {
@@ -147,6 +148,9 @@ namespace Perpetuum.Accounting
 
         private static double GetExperienceBoostingFactor(int collectedEpSum, double epLevelThreshold)
         {
+            if (collectedEpSum < GAURANTEED_BOOST_MAX_THRESH)
+                return 1.0;
+
             var linearRatio = collectedEpSum / epLevelThreshold;
             var result = 1.0 - linearRatio;
             result = result.Clamp();


### PR DESCRIPTION
Just do linear, nuances of power curves are hard to sell.
Because of the starting EP boost, players will be at 24x - this will be confusing if all of our literature states players start at 25x and will be a perceived nerf on new players.

Hence the threshold constant, which steps down nicely into 24x.  