### PR TITLE
GM command: change corp name

### DIFF
--- a/src/Perpetuum/Services/Channels/GameAdminCommands.cs
+++ b/src/Perpetuum/Services/Channels/GameAdminCommands.cs
@@ -1,4 +1,5 @@
 ﻿using Perpetuum.Accounting.Characters;
+using Perpetuum.Groups.Corporations;
 using Perpetuum.ExportedTypes;
 using Perpetuum.GenXY;
 using Perpetuum.Host.Requests;
@@ -769,6 +770,19 @@ namespace Perpetuum.Services.Channels
                 channel.SendMessageToAll(sessionManager, sender, string.Format("Player with nick {0} is offensive:{1}", charactersession.Character.Nick, charactersession.Character.IsOffensiveNick));
 
             }
+
+            if (command[0] == "#renamecorp")
+            {
+                string currentCorpName = command[1];
+                string newCorpName = command[2];
+                string newCorpNick = command[3];
+
+                var corp = Corporation.GetByName(currentCorpName);
+                corp.SetName(newCorpName, newCorpNick);
+
+                channel.SendMessageToAll(sessionManager, sender, string.Format("Corp with nick {0} changed to: {1} [{2}]", currentCorpName, newCorpName, newCorpNick));
+            }
+
 
             //FreeAllLockedEP for account - by request of player
             if (command[0] == "#unlockallep")

--- a/src/Perpetuum/Services/Channels/GameAdminCommands.cs
+++ b/src/Perpetuum/Services/Channels/GameAdminCommands.cs
@@ -774,13 +774,14 @@ namespace Perpetuum.Services.Channels
             if (command[0] == "#renamecorp")
             {
                 string currentCorpName = command[1];
-                string newCorpName = command[2];
-                string newCorpNick = command[3];
+                string desiredCorpName = command[2];
+                string desiredCorpNick = command[3];
 
+                Corporation.IsNameOrNickTaken(desiredCorpName, desiredCorpNick).ThrowIfTrue(ErrorCodes.NameTaken);
                 var corp = Corporation.GetByName(currentCorpName);
-                corp.SetName(newCorpName, newCorpNick);
+                corp.SetName(desiredCorpName, desiredCorpNick);
 
-                channel.SendMessageToAll(sessionManager, sender, string.Format("Corp with nick {0} changed to: {1} [{2}]", currentCorpName, newCorpName, newCorpNick));
+                channel.SendMessageToAll(sessionManager, sender, string.Format("Corp with nick {0} changed to: {1} [{2}]", currentCorpName, desiredCorpName, desiredCorpNick));
             }
 
 


### PR DESCRIPTION
Provide the name of the corp to change (note that the strings as parsed include the spaces!)
example:
`#renamecorp,CurrentCorpName,NewCorpName,NEWTK`

This will not show up in rename history.
This will break things that require name consistency - like the killboards.  Users requesting a change should be made aware of this.  Users that create offensive names don't get the pleasure of maintaining a clean killboard history.