### PR TITLE
100% Corp tax no longer exits the reward loop

### DIFF
--- a/src/Perpetuum/Services/MissionEngine/Missions/MissionInProgress.cs
+++ b/src/Perpetuum/Services/MissionEngine/Missions/MissionInProgress.cs
@@ -1568,11 +1568,12 @@ namespace Perpetuum.Services.MissionEngine.Missions
                     }
                 }
 
+                double amountToCharacter;
                 //if the complete reward is paid to the corporation
                 if (Math.Abs(taxRatio - 1.0) < double.Epsilon)
-                    continue;
-
-                var amountToCharacter = Math.Round((1 - taxRatio)*realRewardFeePerCharacter);
+                    amountToCharacter = 0d;
+                else
+                    amountToCharacter = Math.Round((1 - taxRatio)*realRewardFeePerCharacter);
 
                 oneCharacterPayOut.Add(k.fee, amountToCharacter);
                 paymentsPerCharacter.Add("p" + count++, oneCharacterPayOut);


### PR DESCRIPTION
Fixes [#169](https://github.com/OpenPerpetuum/OP-Project/issues/169)

When the corporation tax is set to 100%, instead of exiting the current loop iteration, set the reward to 0 manually and continue as normal.