### PR TITLE
Outpost Stability cap increase + fixes

### DIFF
--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -26,7 +26,7 @@ namespace Perpetuum.Zones.Intrusion
     {
         private const int EP_WINNER = 120;
         private const int EP_LOSER = 20;
-        private const int MAX_STABILITY = 150;
+        private const int MAX_STABILITY = 120;
         private const int PRODUCTION_BONUS_THRESHOLD = 100;
 
         private TimeRange _intrusionWaitTime => IntrusionWaitTime;

--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -26,6 +26,8 @@ namespace Perpetuum.Zones.Intrusion
     {
         private const int EP_WINNER = 120;
         private const int EP_LOSER = 20;
+        private const int MAX_STABILITY = 150;
+        private const int PRODUCTION_BONUS_THRESHOLD = 100;
 
         private TimeRange _intrusionWaitTime => IntrusionWaitTime;
         private readonly IEntityServices _entityServices;
@@ -367,11 +369,11 @@ namespace Perpetuum.Zones.Intrusion
                         //Stability increase if winner is owner OR winner is in good standing with owner
                         if (winnerCorporation.Eid == siteInfo.Owner || ownerAndWinnerGoodRelation)
                         {
-                            newStability = (newStability + sap.StabilityChange).Clamp(0, 100);
+                            newStability = (newStability + sap.StabilityChange).Clamp(0, MAX_STABILITY);
                         }
                         else
                         {
-                            newStability = (newStability - sap.StabilityChange).Clamp(0, 100);
+                            newStability = (newStability - sap.StabilityChange).Clamp(0, MAX_STABILITY);
 
                             // csak akkor ha 0 lett a stability
                             if (newStability == 0)
@@ -529,6 +531,9 @@ namespace Perpetuum.Zones.Intrusion
         /// </summary>
         private void ProductionStabilityGain(int newStability, int oldStability, long? newOwner)
         {
+            if (oldStability > PRODUCTION_BONUS_THRESHOLD)
+                return; //Do nothing if old stability > 100
+
             var siteInfo = GetIntrusionSiteInfo();
             var oldProductionPoints = (int) (oldStability/10.0);
             var newProductionPoints = (int) (newStability/10.0);
@@ -558,6 +563,9 @@ namespace Perpetuum.Zones.Intrusion
         /// </summary>
         private void ProductionStabilityLoss(int newStability, int oldStability, long? newOwner, long? oldOwner)
         {
+            if (newStability > PRODUCTION_BONUS_THRESHOLD)
+                return; //Do nothing if new stability > 100
+
             var siteInfo = GetIntrusionSiteInfo();
             var oldProductionPoints = (int)(oldStability / 10.0);
             var newProductionPoints = (int)(newStability / 10.0);


### PR DESCRIPTION
Production points had some assumptions about the 100 pt threshold.  Now changes above 100 will not affect production facility point investments.

Ready for review!
Question: What should the new stability threshold be? Design Team feedback requested!

Closes: https://github.com/OpenPerpetuum/OP-Project/issues/160