### PR TITLE
Decay reset on owner any owner SAE activity & on new ownership

### DIFF
--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -34,7 +34,6 @@ namespace Perpetuum.Zones.Intrusion
         private const int PRODUCTION_BONUS_THRESHOLD = 100;
 
         private TimeRange _intrusionWaitTime => IntrusionWaitTime;
-        private TimeSpan _timeSinceLastSAP = TimeSpan.Zero;
         private readonly IEntityServices _entityServices;
         private readonly ICorporationManager _corporationManager;
         private readonly ILootService _lootService;

--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -331,7 +331,7 @@ namespace Perpetuum.Zones.Intrusion
 
         private void OnSAPTakeOver(SAP sap)
         {
-            _decay.OnSAP();
+            
             Task.Run(() => HandleTakeOver(sap)).ContinueWith(t => IntrusionInProgress = false);
         }
 
@@ -402,6 +402,12 @@ namespace Perpetuum.Zones.Intrusion
             var newStability = siteInfo.Stability;
             var newOwner = siteInfo.Owner;
             var oldOwner = siteInfo.Owner;
+
+            // Reset Decay timer on any StabilityAffectingEvent completed by the owner
+            if (winnerCorporation.Eid == siteInfo.Owner)
+            {
+                _decay.OnSAP();
+            }
 
             var logEvent = new IntrusionLogEvent
             {

--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -406,7 +406,7 @@ namespace Perpetuum.Zones.Intrusion
             // Reset Decay timer on any StabilityAffectingEvent completed by the owner
             if (winnerCorporation.Eid == siteInfo.Owner)
             {
-                _decay.OnSAP();
+                _decay.ResetDecayTimer();
             }
 
             var logEvent = new IntrusionLogEvent
@@ -460,6 +460,7 @@ namespace Perpetuum.Zones.Intrusion
                     logEvent.EventType = IntrusionEvents.siteOwnershipGain;
                     newOwner = winnerCorporation.Eid;
                     newStability = STARTING_STABILITY;
+                    _decay.ResetDecayTimer();
                 }
                 else
                 {

--- a/src/Perpetuum/Zones/Intrusion/OutpostDecay.cs
+++ b/src/Perpetuum/Zones/Intrusion/OutpostDecay.cs
@@ -42,7 +42,7 @@ namespace Perpetuum.Zones.Intrusion
         /// <summary>
         /// Called when a SAP is completed
         /// </summary>
-        public void OnSAP()
+        public void ResetDecayTimer()
         {
             lastSuccessfulIntrusion = TimeSpan.Zero;
         }


### PR DESCRIPTION
Reset the decay grace-period timer IFF the owner does any StabilityAffectingEvent.
Also if the outpost is newly taken-over.  woops

As desired by design team.