### PR TITLE
Destro bug fix; StabilityAffectingEvent refactor

### DIFF
--- a/src/Perpetuum/Services/EventServices/EventMessages/StabilityEffectMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/StabilityEffectMessage.cs
@@ -10,38 +10,34 @@ namespace Perpetuum.Services.EventServices.EventMessages
     /// </summary>
     public class StabilityAffectingEvent : EventMessage
     {
-        private Player _player;
+        public Corporation Winner { get; private set; }
+        public Outpost Outpost { get; private set; }
+        public bool OverrideRelations { get; private set; }
+        public int StabilityChange { get; private set; }
+        public int Definition { get; private set; }
+        public long? Eid { get; private set; }
         private List<Player> _participants = new List<Player>();
-        public Outpost Outpost { get; }
-        public bool OverrideRelations { get; }
-        public int StabilityChange { get; }
-        public int Definition { get; }
-        public long? Eid { get; }
-
-        public StabilityAffectingEvent(Outpost outpost, Player winner, int def, long? eid, int sapPoints, IList<Player> participants = null, bool overrideRelations = false)
+        public List<Player> Participants
         {
-            Outpost = outpost;
-            _player = winner;
-            StabilityChange = sapPoints;
-            Definition = def;
-            Eid = eid;
-            if (participants != null)
+            get
             {
-                _participants = participants as List<Player>;
+                _participants.RemoveAll(p => p == null);
+                return _participants;
             }
-            
-            OverrideRelations = overrideRelations;
+            private set
+            {
+                _participants = value;
+            }
+        }
+
+        public static StabilityAffectBuilder Builder()
+        {
+            return new StabilityAffectBuilder();
         }
 
         public bool IsSystemGenerated()
         {
-            return _player == null;
-        }
-
-        public IList<Player> GetPlayers()
-        {
-            _participants.RemoveAll(p => p == null);
-            return _participants;
+            return Winner == null;
         }
 
         [CanBeNull]
@@ -49,7 +45,74 @@ namespace Perpetuum.Services.EventServices.EventMessages
         {
             if (IsSystemGenerated())
                 return Corporation.GetByName("syndicate_police_central");
-            return Corporation.Get(_player.CorporationEid);
+            return Winner;
+        }
+
+        public class StabilityAffectBuilder
+        {
+            private Outpost _outpost;
+            private Corporation _winnerCorp;
+            private int _definition;
+            private long? _entityId;
+            private int _sapPoints;
+            private List<Player> _participants = new List<Player>();
+            private bool _overrideRelations = false;
+
+            public StabilityAffectingEvent Build()
+            {
+                var s = new StabilityAffectingEvent
+                {
+                    Outpost = _outpost,
+                    Winner = _winnerCorp,
+                    Participants = _participants,
+                    Definition = _definition,
+                    Eid = _entityId,
+                    StabilityChange = _sapPoints,
+                    OverrideRelations = _overrideRelations
+                };
+                return s;
+            }
+
+            public StabilityAffectBuilder WithOutpost(Outpost outpost)
+            {
+                _outpost = outpost;
+                return this;
+            }
+            public StabilityAffectBuilder AddParticipant(Player player)
+            {
+                _participants.Add(player);
+                return this;
+            }
+            public StabilityAffectBuilder AddParticipants(IList<Player> players)
+            {
+                _participants.AddMany(players);
+                return this;
+            }
+            public StabilityAffectBuilder WithWinnerCorp(long corpEid)
+            {
+                _winnerCorp = Corporation.Get(corpEid);
+                return this;
+            }
+            public StabilityAffectBuilder WithSapDefinition(int definition)
+            {
+                _definition = definition;
+                return this;
+            }
+            public StabilityAffectBuilder WithSapEntityID(long eid)
+            {
+                _entityId = eid;
+                return this;
+            }
+            public StabilityAffectBuilder WithPoints(int sapPoints)
+            {
+                _sapPoints = sapPoints;
+                return this;
+            }
+            public StabilityAffectBuilder WithOverrideRelations(bool isOverride)
+            {
+                _overrideRelations = isOverride;
+                return this;
+            }
         }
     }
 }

--- a/src/Perpetuum/Services/Relics/Relics/SAPRelic.cs
+++ b/src/Perpetuum/Services/Relics/Relics/SAPRelic.cs
@@ -29,8 +29,15 @@ namespace Perpetuum.Services.Relics
 
         public override void PopRelic(Player player)
         {
+            var builder = StabilityAffectingEvent.Builder()
+                .WithOutpost(_outpost)
+                .WithSapDefinition(Definition)
+                .WithSapEntityID(Eid)
+                .WithPoints(1)
+                .AddParticipant(player)
+                .WithWinnerCorp(player.CorporationEid);
             player.ApplyPvPEffect();
-            _outpost.PublishSAPEvent(new StabilityAffectingEvent(_outpost, player, this.Definition, this.Eid, 1));
+            _outpost.PublishSAPEvent(builder.Build());
             base.PopRelic(player);
         }
     }

--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -347,7 +347,7 @@ namespace Perpetuum.Zones.Intrusion
                 {
                     var gen = new LootGenerator(_lootService.GetIntrusionLootInfos(this, sap));
                     LootContainer.Create().AddLoot(gen).BuildAndAddToZone(Zone, sap.CurrentPosition);
-                    processStabilityChange(sap.toStabilityAffectingEvent());
+                    ProcessStabilityChange(sap.ToStabilityAffectingEvent());
                     scope.Complete();
                 }
                 catch (Exception ex)
@@ -370,7 +370,7 @@ namespace Perpetuum.Zones.Intrusion
             {
                 try
                 {
-                    processStabilityChange(sap);
+                    ProcessStabilityChange(sap);
                     scope.Complete();
                 }
                 catch (Exception ex)
@@ -385,7 +385,7 @@ namespace Perpetuum.Zones.Intrusion
         /// <summary>
         /// Core SAP logic
         /// </summary>
-        private void processStabilityChange(StabilityAffectingEvent sap)
+        private void ProcessStabilityChange(StabilityAffectingEvent sap)
         {
             // Check for invalid player-SAPS
             var winnerCorporation = sap.GetWinnerCorporation();
@@ -484,7 +484,7 @@ namespace Perpetuum.Zones.Intrusion
             InsertIntrusionLog(logEvent);
 
             //Award EP
-            foreach (var player in sap.GetPlayers())
+            foreach (var player in sap.Participants)
             {
                 player.Character.AddExtensionPointsBoostAndLog(EpForActivityType.Intrusion, EP_WINNER);
             }

--- a/src/Perpetuum/Zones/Intrusion/OutpostDecay.cs
+++ b/src/Perpetuum/Zones/Intrusion/OutpostDecay.cs
@@ -10,19 +10,22 @@ namespace Perpetuum.Zones.Intrusion
     /// </summary>
     public class OutpostDecay
     {
-        private readonly Outpost _outpost;
         private readonly EventListenerService _eventChannel;
         private readonly static TimeSpan noDecayBefore = TimeSpan.FromDays(3);
         private readonly static TimeSpan decayRate = TimeSpan.FromDays(1);
         private TimeSpan timeSinceLastDecay = TimeSpan.Zero;
         private TimeSpan lastSuccessfulIntrusion = TimeSpan.Zero;
         private readonly static int decayPts = -5;
-        private readonly EntityDefault def = EntityDefault.GetByName("def_outpost_decay");
+        private StabilityAffectingEvent.StabilityAffectBuilder _builder;
 
         public OutpostDecay(EventListenerService eventChannel, Outpost outpost)
         {
-            _outpost = outpost;
             _eventChannel = eventChannel;
+            var def = EntityDefault.GetByName("def_outpost_decay");
+             _builder = StabilityAffectingEvent.Builder()
+                .WithOutpost(outpost)
+                .WithSapDefinition(def.Definition)
+                .WithPoints(decayPts);
         }
 
         public void OnUpdate(TimeSpan time)
@@ -49,7 +52,7 @@ namespace Perpetuum.Zones.Intrusion
 
         private void DoDecay()
         {
-            _eventChannel.PublishMessage(new StabilityAffectingEvent(_outpost, null, def.Definition, null, decayPts));
+            _eventChannel.PublishMessage(_builder.Build());
         }
     }
 }

--- a/src/Perpetuum/Zones/Intrusion/SAP.cs
+++ b/src/Perpetuum/Zones/Intrusion/SAP.cs
@@ -327,15 +327,21 @@ namespace Perpetuum.Zones.Intrusion
         /// Adapter method for SAP->StabilityAffectingEvent
         /// </summary>
         /// <returns>StabilityAffectingEvent</returns>
-        public StabilityAffectingEvent toStabilityAffectingEvent()
+        public StabilityAffectingEvent ToStabilityAffectingEvent()
         {
             List<Player> players = new List<Player>();
             foreach(var player in this.PlayerInfos)
             {
                 players.Add(player.character.GetPlayerRobotFromZone());
             }
-            var winner = GetPlayerTopScores(1)[0].character.GetPlayerRobotFromZone();
-            return new StabilityAffectingEvent(Site, winner, Definition, Eid, StabilityChange, players);
+            var builder = StabilityAffectingEvent.Builder()
+                .WithOutpost(Site)
+                .WithSapDefinition(Definition)
+                .WithSapEntityID(Eid)
+                .WithPoints(StabilityChange)
+                .AddParticipants(players)
+                .WithWinnerCorp(GetWinnerCorporationEid());
+            return builder.Build();
         }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/NPCBossInfo.cs
+++ b/src/Perpetuum/Zones/NpcSystem/NPCBossInfo.cs
@@ -107,14 +107,15 @@ namespace Perpetuum.Zones.NpcSystem
                 if (outpost is Outpost)
                 {
                     var participants = npc.ThreatManager.Hostiles.Select(x => zone.ToPlayerOrGetOwnerPlayer(x.unit)).ToList();
-                    EventMessage sapMessage = new StabilityAffectingEvent(outpost as Outpost,
-                        zone.ToPlayerOrGetOwnerPlayer(killer),
-                        npc.Definition,
-                        npc.Eid,
-                        StabilityPoints(),
-                        participants,
-                        OverrideRelations());
-                    channel.PublishMessage(sapMessage);
+                    var builder = StabilityAffectingEvent.Builder()
+                        .WithOutpost(outpost as Outpost)
+                        .WithOverrideRelations(OverrideRelations())
+                        .WithSapDefinition(npc.Definition)
+                        .WithSapEntityID(npc.Eid)
+                        .WithPoints(StabilityPoints())
+                        .AddParticipants(participants)
+                        .WithWinnerCorp(zone.ToPlayerOrGetOwnerPlayer(killer).CorporationEid);
+                    channel.PublishMessage(builder.Build());
                 }
             }
         }


### PR DESCRIPTION
Closes: #131 

The actual bug is that 1 player that does the most damage will win, even if many players from another corp do more damage total, but not more damage than the 1 player from the other corp. (Not the "last shot" as reported)

Because StabilityAffectingEvent's have many potential configurations, a builder pattern was introduced to simplify their construction with this change.  This class will be used in the future for more SAP events.
