### PR TITLE
Hitsize affects cover in LOS: hitsize modifier

### DIFF
--- a/src/Perpetuum/Zones/LineOfSight.cs
+++ b/src/Perpetuum/Zones/LineOfSight.cs
@@ -55,7 +55,8 @@ namespace Perpetuum.Zones
 
             if (targetUnit.HitSize > 0)
             {
-                len = (float)CylinderIntersection(source,direction,targetUnit.CurrentPosition.ToVector3(),target,targetUnit.HitSize);
+                var hitsize = targetUnit.HitSize * 0.6;
+                len = (float)CylinderIntersection(source, direction, targetUnit.CurrentPosition.ToVector3(), target, hitsize);
             }
 
             return IsInLineOfSight(zone,source,direction,len,ballistic);

--- a/src/Perpetuum/Zones/LineOfSight.cs
+++ b/src/Perpetuum/Zones/LineOfSight.cs
@@ -55,14 +55,14 @@ namespace Perpetuum.Zones
 
             if (targetUnit.HitSize > 0)
             {
-                var hitsize = targetUnit.HitSize * 0.6;
+                var hitsize = (targetUnit.HitSize * 0.5).Clamp(1, 10);
                 len = (float)CylinderIntersection(source, direction, targetUnit.CurrentPosition.ToVector3(), target, hitsize);
             }
 
-            return IsInLineOfSight(zone,source,direction,len,ballistic);
+            return IsInLineOfSight(zone, source, direction, len, ballistic);
         }
 
-        private static double CylinderIntersection(Vector3 start,Vector3 dir,Vector3 cylinderStart,Vector3 cylinderEnd,double radius)
+        private static double CylinderIntersection(Vector3 start, Vector3 dir, Vector3 cylinderStart, Vector3 cylinderEnd, double radius)
         {
             var ab = cylinderEnd - cylinderStart;
             var ao = start - cylinderStart;


### PR DESCRIPTION
Large srf-areas can exceed the size of tiles which puts the hit-cylinder of a robot on the other side of single-tile blocking objects.

This is largely experimental at the moment.  Design team will have to discuss what larger srf-areas should and should not be blocked by.