### PR TITLE
Relic Location robustify

### DIFF
--- a/src/Perpetuum/Services/Relics/RelicManagers/OutpostRelicManager.cs
+++ b/src/Perpetuum/Services/Relics/RelicManagers/OutpostRelicManager.cs
@@ -16,17 +16,17 @@ namespace Perpetuum.Services.Relics
         private readonly TimeSpan RESPAWN_RANDOM_WINDOW = TimeSpan.FromHours(1);
         private readonly TimeSpan _respawnRate = TimeSpan.FromHours(4);
 
-        private Outpost _outpost;
-        private Random _random;
-        private RelicInfo _sapRelicInfo;
+        private readonly Outpost _outpost;
+        private readonly Random _random;
+        private readonly RelicInfo _sapRelicInfo;
 
         //Beam Draw refresh
         private readonly TimeSpan _relicRefreshRate = TimeSpan.FromSeconds(19.95);
 
         // Spawn range and area
-        private readonly int SPAWN_MINIMUM_OUTPOST_DISTANCE = 90;
-        private readonly int SPAWN_MAXIMUM_OUTPOST_DISTANCE = 350;
-        private readonly int SPAWN_AREA_REQUIRED_SIZE = 200;
+        private const int SPAWN_MINIMUM_OUTPOST_DISTANCE = 90;
+        private const int SPAWN_MAXIMUM_OUTPOST_DISTANCE = 350;
+        private const int SPAWN_AREA_REQUIRED_SIZE = 3000;
 
         private IZone _zone;
         protected override IZone Zone
@@ -77,30 +77,20 @@ namespace Perpetuum.Services.Relics
 
         protected override Point FindRelicPosition(RelicInfo info)
         {
-            Position p = new Position();
-            Position invalidPosition = new Position(0, 0);
-
-            List<Point> result = null;
             for(int i = 0; i < 10; i++)
             {
                 var randomPos = _outpost.CurrentPosition.GetRandomPositionInRange2D(
                     SPAWN_MINIMUM_OUTPOST_DISTANCE, SPAWN_MAXIMUM_OUTPOST_DISTANCE);
                 var posFinder = new ClosestWalkablePositionFinder(_zone, randomPos);
 
-                posFinder.Find(out p);
-                result = _zone.FindWalkableArea(p, _zone.Size.ToArea(), SPAWN_AREA_REQUIRED_SIZE);
+                posFinder.Find(out Position p);
+                var result = _zone.FindWalkableArea(p, _zone.Size.ToArea(), SPAWN_AREA_REQUIRED_SIZE);
                 if(result != null)
                 {
-                    break;
+                    return p;
                 }
             }
-
-            if (result == null)
-            {
-                p = invalidPosition;
-            }
-
-            return p;
+            return Point.Empty;
         }
 
         protected override void RefreshBeam(IRelic relic)

--- a/src/Perpetuum/Services/Relics/Relics/AbstractRelic.cs
+++ b/src/Perpetuum/Services/Relics/Relics/AbstractRelic.cs
@@ -20,8 +20,8 @@ namespace Perpetuum.Services.Relics
         protected bool _alive;
 
         protected const double ACTIVATION_RANGE = 3; //30m
-        protected readonly TimeSpan MAXLIFESPAN = TimeSpan.FromDays(3);
         protected TimeSpan lifespan = TimeSpan.Zero;
+        protected virtual TimeSpan MAXLIFESPAN { get { return TimeSpan.FromDays(3); } }
 
         // Locks - Be sure to use locks independently and do not nest calls into other locks!
         // Lock for Live/Dead state of Relic

--- a/src/Perpetuum/Services/Relics/Relics/SAPRelic.cs
+++ b/src/Perpetuum/Services/Relics/Relics/SAPRelic.cs
@@ -3,12 +3,14 @@ using Perpetuum.Players;
 using Perpetuum.Services.EventServices.EventMessages;
 using Perpetuum.Zones;
 using Perpetuum.Zones.Intrusion;
+using System;
 
 namespace Perpetuum.Services.Relics
 {
     public class SAPRelic : AbstractRelic
     {
         private Outpost _outpost;
+        protected override TimeSpan MAXLIFESPAN { get { return TimeSpan.FromHours(12); } }
 
         [CanBeNull]
         public static IRelic BuildAndAddToZone(RelicInfo info, IZone zone, Position position, RelicLootItems lootItems, Outpost outpost)


### PR DESCRIPTION
Astar is still too expensive, even if just used as a verification step, not as the primary position test algorithm.
Floodfill parameter to increase to address relic spawning in altitude maxima/plateaus.
Estimated cost increase 10x (Astar would be 500-1000x!)
Tolerable, and happens on a separate thread to player activity, so not a killer even if we had to go with Astar for 100% guarantee walkability for players.

@clouths, touched your code, so give it a look-over in case you see anything you might like changed.

Closes: https://github.com/OpenPerpetuum/PerpetuumServer/issues/153
Closes: https://github.com/OpenPerpetuum/PerpetuumServer/issues/152