### PR TITLE
AOE bot-death damage radius + LOS fix for 0 distance

### DIFF
--- a/src/Perpetuum/Units/Unit.cs
+++ b/src/Perpetuum/Units/Unit.cs
@@ -482,9 +482,21 @@ namespace Perpetuum.Units
             Task.Delay(FastRandom.NextInt(0, 3000)).ContinueWith(t => zone.DoAoeDamage(damageBuilder));
         }
 
+        /// <summary>
+        /// Fitted curve to achieve desired explosion distances for bots of certain sizes by class
+        /// Ensures output will be bounded and that arbitrary input will not result in error or undesired output
+        /// </summary>
+        /// <param name="x">SignativeRadius of bot</param>
+        /// <returns>Radius in number of tiles (10m)</returns>
+        private double SigRadiusToExplosionRadius(double x)
+        {
+            x = x.Clamp(3.0, 40.0);
+            return (-3.336453 + 1.617863 * x - 0.09721877 * (x * x) + 0.002064723 * (x * x * x)).Clamp(1.0, 30.0);
+        }
+
         private IDamageBuilder GetExplosionDamageBuilder()
         {
-            var radius = SignatureRadius * 0.5; //Note: reduced for increased bot srf-areas
+            var radius = SigRadiusToExplosionRadius(SignatureRadius);
             var damageBuilder = DamageInfo.Builder.WithAttacker(this)
                                           .WithOptimalRange(1)
                                           .WithFalloff(radius)
@@ -500,7 +512,7 @@ namespace Perpetuum.Units
             if (coreMax.IsZero())
                 coreMax = 1.0;
 
-            var damage = (Math.Sin( Core.Ratio(coreMax) * Math.PI) + 1)*(armorMaxValue*0.1);
+            var damage = (Math.Sin(Core.Ratio(coreMax) * Math.PI) + 1) * (armorMaxValue * 0.1);
             damageBuilder.WithAllDamageTypes(damage);
             return damageBuilder;
         }

--- a/src/Perpetuum/ValueTypeExtensions.cs
+++ b/src/Perpetuum/ValueTypeExtensions.cs
@@ -85,6 +85,18 @@ namespace Perpetuum
             return Math.Abs(num) < float.Epsilon;
         }
 
+        public static bool IsApproximatelyEqual(this double left, double right, double precision = 0.0000001)
+        {
+            var result = Math.Abs(left - right);
+            return result <= precision;
+        }
+
+        public static bool IsApproximatelyEqual(this float left, float right, float precision = 0.0000001f)
+        {
+            var result = Math.Abs(left - right);
+            return result <= precision;
+        }
+
         public static double Clamp(this double value, double lowerBound = 0.0, double upperBound = 1.0)
         {
             return Math.Min(upperBound, Math.Max(lowerBound, value));

--- a/src/Perpetuum/Zones/LineOfSight.cs
+++ b/src/Perpetuum/Zones/LineOfSight.cs
@@ -100,7 +100,7 @@ namespace Perpetuum.Zones
         [NotNull]
         private static LOSResult IsInLineOfSight(IZone zone, Vector3 origin, Vector3 direction, float distance, bool ballistic)
         {
-            if (distance == 0.0)
+            if (distance.IsApproximatelyEqual(0.0f))
             {
                 var blockingInfo = zone.Terrain.Blocks.GetValue(origin);
                 var losResult = new LOSResult

--- a/src/Perpetuum/Zones/LineOfSight.cs
+++ b/src/Perpetuum/Zones/LineOfSight.cs
@@ -98,8 +98,20 @@ namespace Perpetuum.Zones
         }
 
         [NotNull]
-        private static LOSResult IsInLineOfSight(IZone zone,Vector3 origin,Vector3 direction,float distance,bool ballistic)
+        private static LOSResult IsInLineOfSight(IZone zone, Vector3 origin, Vector3 direction, float distance, bool ballistic)
         {
+            if (distance == 0.0)
+            {
+                var blockingInfo = zone.Terrain.Blocks.GetValue(origin);
+                var losResult = new LOSResult
+                {
+                    hit = true,
+                    position = (Position)origin,
+                    blockingFlags = blockingInfo.Flags
+                };
+                return losResult;
+            }
+
             var lastAltitude = zone.Terrain.Altitude.GetAltitudeAsDouble(origin) + 2;
 
             var lx = (int) origin.X;


### PR DESCRIPTION
Ok should be separate PR's but npcs on the same tile was where we see this occurring most so it was easier to test and fix while working on the other issue.

The srf-area-to-falloff-range curve is bespoke but continuous and smooth for the ranges of bot sizes and srf-area modifying equipment.  Because HMechs are significantly larger, it was no longer possible to keep this linear without some very large consequences.

The output is bounded to allow hard floors/ceilings to prevent runaway explosion sizes with future/potential srf-areas to come.

The details for the data used to interpolate this curve are in the balance team design docs, the specifics of which can be debated there.

Closes #140 
Because direction at 0 distance can't be computed, let's handle that case.  
Debatable point: Now that it is not throwing exceptions, should it result in a valid hit or miss?