### PR TITLE
Fix: Spawned state on NPCReinforcementWaves

### DIFF
--- a/src/Perpetuum/Services/EventServices/EventProcessors/OreNPCSpawner.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/OreNPCSpawner.cs
@@ -19,6 +19,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
     public class OreNpcSpawner : EventProcessor<EventMessage>
     {
         private const int SPAWN_DIST_FROM_FIELD = 100;
+        private const int SPAWN_AREA_REQUIRED_SIZE = 3000;
         private readonly TimeSpan ORE_SPAWN_LIFETIME = TimeSpan.FromHours(3);
         private readonly TimeSpan SPAWN_DELAY = TimeSpan.FromSeconds(10);
 
@@ -71,7 +72,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
                 var pos = start.OffsetInDirection(random, range);
                 var posFinder = new ClosestWalkablePositionFinder(_zone, pos);
                 posFinder.Find(out Position p);
-                var result = _zone.FindWalkableArea(p, _zone.Size.ToArea(), 100);
+                var result = _zone.FindWalkableArea(p, _zone.Size.ToArea(), SPAWN_AREA_REQUIRED_SIZE);
                 if (result != null)
                 {
                     return p;

--- a/src/Perpetuum/Services/EventServices/EventProcessors/OreNPCSpawner.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/OreNPCSpawner.cs
@@ -136,7 +136,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
         {
             var pres = _zone.AddDynamicPresenceToPosition(wave.PresenceId, homePosition, spawnPosition, ORE_SPAWN_LIFETIME);
             pres.PresenceExpired += OnPresenceExpired;
-            wave.ActivePresence = pres;
+            wave.SetActivePresence(pres);
         }
 
         private bool _spawning = false;

--- a/src/Perpetuum/Zones/NpcSystem/Reinforcements/INpcReinforcementWave.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Reinforcements/INpcReinforcementWave.cs
@@ -8,9 +8,15 @@ namespace Perpetuum.Zones.NpcSystem.Reinforcements
     public interface INpcReinforcementWave
     {
         int PresenceId { get; }
-        DynamicPresence ActivePresence { get; set; }
+        DynamicPresence ActivePresence { get; }
         double Threshold { get; }
         bool Spawned { get; }
+
+        /// <summary>
+        /// Set the ActivePresence and mark this wave as "Spawned"
+        /// </summary>
+        /// <param name="presence">presence that is spawned to the zone</param>
+        void SetActivePresence(DynamicPresence presence);
 
         /// <summary>
         /// Test if the provided presence is the ActivePresence of this wave

--- a/src/Perpetuum/Zones/NpcSystem/Reinforcements/NpcReinforcementWave.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Reinforcements/NpcReinforcementWave.cs
@@ -6,8 +6,8 @@ namespace Perpetuum.Zones.NpcSystem.Reinforcements
     {
         public int PresenceId { get; }
         public double Threshold { get; }
-        public bool Spawned => ActivePresence != null;
-        public DynamicPresence ActivePresence { get; set; }
+        public bool Spawned { get; private set; }
+        public DynamicPresence ActivePresence { get; private set; }
 
         public NpcReinforcementWave(int presenceID, double threshold)
         {
@@ -18,6 +18,12 @@ namespace Perpetuum.Zones.NpcSystem.Reinforcements
         public override string ToString()
         {
             return $"{Threshold}:{PresenceId} Spawned? {Spawned}";
+        }
+
+        public void SetActivePresence(DynamicPresence presence)
+        {
+            ActivePresence = presence;
+            Spawned = true;
         }
 
         public bool IsActivePresence(Presence presence)


### PR DESCRIPTION
Broke this in a refactor - awesome

Intended behaviour is that each wave spawns once, was broken if spawn was killed before threshold was met.  
