### PR TITLE
Resolve orphan players on zone

### DIFF
--- a/src/Perpetuum/Comparers/EntityComparer.cs
+++ b/src/Perpetuum/Comparers/EntityComparer.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Perpetuum.EntityFramework;
+
+namespace Perpetuum.Comparers
+{
+    public class EntityComparer : IEqualityComparer<IEntity>
+    {
+        public EntityComparer()
+        {
+        }
+
+        public bool Equals(IEntity left, IEntity right)
+        {
+            // If they're both null, technically they're the same...
+            if (ReferenceEquals(left, right)) return true;
+
+            if (left is null || right is null) return false;
+
+            return left.Eid == right.Eid;
+        }
+
+        public int GetHashCode(IEntity obj)
+        {
+            if (obj is null) return 0;
+
+            return obj.Eid.GetHashCode();
+        }
+    }
+}

--- a/src/Perpetuum/EntityFramework/Entity.cs
+++ b/src/Perpetuum/EntityFramework/Entity.cs
@@ -9,7 +9,7 @@ using Perpetuum.ExportedTypes;
 
 namespace Perpetuum.EntityFramework
 {
-    public class Entity
+    public class Entity : IEntity
     {
         public static IEntityServices Services { get; set; }
 

--- a/src/Perpetuum/EntityFramework/IEntity.cs
+++ b/src/Perpetuum/EntityFramework/IEntity.cs
@@ -3,6 +3,6 @@ namespace Perpetuum.EntityFramework
 {
     public interface IEntity
     {
-        public long Eid { get; }
+        long Eid { get; }
     }
 }

--- a/src/Perpetuum/EntityFramework/IEntity.cs
+++ b/src/Perpetuum/EntityFramework/IEntity.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Perpetuum.EntityFramework
+{
+    public interface IEntity
+    {
+        public long Eid { get; }
+    }
+}

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -1159,6 +1159,7 @@
     <Compile Include="Zones\ZoneEntityRepositories\ZoneUnitService.cs" />
     <Compile Include="Zones\ZoneExitType.cs" />
     <Compile Include="Zones\ZoneManager.cs" />
+    <Compile Include="Zones\SessionlessPlayerTimeout.cs" />
     <Compile Include="Zones\ZoneSession.cs" />
     <Compile Include="Zones\ZoneSessionExtensions.cs" />
     <Compile Include="Zones\ZoneStorage.cs" />

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -78,7 +78,6 @@
       <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -93,7 +92,6 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -1165,6 +1163,8 @@
     <Compile Include="Zones\ZoneStorage.cs" />
     <Compile Include="Zones\ZoneTicket.cs" />
     <Compile Include="Zones\ZoneType.cs" />
+    <Compile Include="Comparers\EntityComparer.cs" />
+    <Compile Include="EntityFramework\IEntity.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -1207,6 +1207,7 @@
     <Folder Include="Properties\" />
     <Folder Include="Services\ProductionEngine\Methods\" />
     <Folder Include="Services\Relay\RequestHandlers\" />
+    <Folder Include="Comparers\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
+++ b/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
@@ -1,5 +1,4 @@
-﻿using Perpetuum.Log;
-using Perpetuum.Players;
+﻿using Perpetuum.Players;
 using Perpetuum.Timers;
 using System;
 using System.Collections.Generic;

--- a/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
+++ b/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
@@ -7,17 +7,20 @@ using System.Linq;
 
 namespace Perpetuum.Zones
 {
+    /// <summary>
+    /// A class used by a Zone to determine if a Player is orphaned by a timeout check on its ZoneSession
+    /// </summary>
     public class SessionlessPlayerTimeout
     {
-        private static readonly TimeSpan MAX_ORPHAN_TIME = TimeSpan.FromMinutes(6);
-        private static readonly TimeSpan UPDATE_RATE = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan MAX_ORPHAN_TIME = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan UPDATE_RATE = TimeSpan.FromMinutes(1);
         private readonly IZone _zone;
-        private readonly IDictionary<long, PlayerTimeout> _orphanPlayers;
+        private IEnumerable<PlayerTimeout> _orphanPlayers;
 
         public SessionlessPlayerTimeout(IZone zone)
         {
             _zone = zone;
-            _orphanPlayers = new Dictionary<long, PlayerTimeout>();
+            _orphanPlayers = new HashSet<PlayerTimeout>();
         }
 
         private TimeSpan _elapsed = TimeSpan.Zero;
@@ -33,35 +36,28 @@ namespace Perpetuum.Zones
 
         private void DoUpdate()
         {
-            Logger.DebugInfo($"Zone:{_zone.Id} Total players: {_zone.Players.Count()} Total orphan players: {_zone.Players.Count(p => p.Session == ZoneSession.None)}");
-
-            // Players on the zone without a session - this is ok unless the session never connects!
-            var playersWithoutSessions = _zone.Players.Where(p => p.Session == ZoneSession.None)
-                .Where(p => !_orphanPlayers.Keys.Contains(p.Eid));
-
-            foreach (var p in playersWithoutSessions)
-            {
-                _orphanPlayers.Add(p.Eid, new PlayerTimeout(p));
-            }
-
-            // Players that are no longer orphaned
-            _orphanPlayers.RemoveRange(_orphanPlayers.Where(o => o.Value.Player.Session != ZoneSession.None).GetKeys().ToArray());
-
-            // Players with Expired timers; Zone assumes the Player has failed to connect and removes them
-            var toRemove = _orphanPlayers.Where(o => o.Value.Expired).ToArray();
-
-            foreach (var o in toRemove)
-            {
-                o.Value.Player.RemoveFromZone();
-                _orphanPlayers.Remove(o.Key);
-                Logger.DebugInfo($"A player w/o session REMOVED: {o.Value.Player}");
-            }
+            _orphanPlayers = AddSessionlessPlayers(_orphanPlayers, _zone);
+            _orphanPlayers = RemoveExpiredOrphansFromZone(_orphanPlayers);
         }
 
-        private class PlayerTimeout
+        private static IEnumerable<PlayerTimeout> AddSessionlessPlayers(IEnumerable<PlayerTimeout> orphans, IZone zone)
+        {
+            var sessionLessPlayers = zone.Players.Where(p => p.Session == ZoneSession.None).Select(p => new PlayerTimeout(p)).ToHashSet();
+            return orphans.Union(sessionLessPlayers).Where(o => o.Player.Session == ZoneSession.None).ToHashSet();
+        }
+
+        private static IEnumerable<PlayerTimeout> RemoveExpiredOrphansFromZone(IEnumerable<PlayerTimeout> orphans)
+        {
+            var toRemove = orphans.Where(o => o.Expired);
+            toRemove.ForEach(o => o.Player.RemoveFromZone());
+            return orphans.Except(toRemove).ToHashSet();
+        }
+
+        private class PlayerTimeout : IEquatable<PlayerTimeout>
         {
             public Player Player { get; private set; }
             public bool Expired { get { return _time.Expired; } }
+            public long Eid { get { return Player is null ? 0 : Player.Eid; } }
             private readonly TimeKeeper _time;
 
             public PlayerTimeout(Player p)
@@ -69,7 +65,32 @@ namespace Perpetuum.Zones
                 _time = new TimeKeeper(MAX_ORPHAN_TIME);
                 Player = p;
             }
-        }
 
+            public bool Equals(PlayerTimeout other)
+            {
+                if (other is null)
+                    return false;
+
+                return ReferenceEquals(this, other) || Eid == other.Eid;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is null)
+                {
+                    return false;
+                }
+                else if (obj is PlayerTimeout pt)
+                {
+                    return Equals(pt);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return Eid.GetHashCode();
+            }
+        }
     }
 }

--- a/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
+++ b/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
@@ -1,0 +1,75 @@
+﻿using Perpetuum.Log;
+using Perpetuum.Players;
+using Perpetuum.Timers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Perpetuum.Zones
+{
+    public class SessionlessPlayerTimeout
+    {
+        private static readonly TimeSpan MAX_ORPHAN_TIME = TimeSpan.FromMinutes(6);
+        private static readonly TimeSpan UPDATE_RATE = TimeSpan.FromMinutes(2);
+        private readonly IZone _zone;
+        private readonly IDictionary<long, PlayerTimeout> _orphanPlayers;
+
+        public SessionlessPlayerTimeout(IZone zone)
+        {
+            _zone = zone;
+            _orphanPlayers = new Dictionary<long, PlayerTimeout>();
+        }
+
+        private TimeSpan _elapsed = TimeSpan.Zero;
+        public void Update(TimeSpan time)
+        {
+            _elapsed += time;
+            if (_elapsed < UPDATE_RATE)
+                return;
+
+            DoUpdate();
+            _elapsed = TimeSpan.Zero;
+        }
+
+        private void DoUpdate()
+        {
+            Logger.DebugInfo($"Zone:{_zone.Id} Total players: {_zone.Players.Count()} Total orphan players: {_zone.Players.Count(p => p.Session == ZoneSession.None)}");
+
+            // Players on the zone without a session - this is ok unless the session never connects!
+            var playersWithoutSessions = _zone.Players.Where(p => p.Session == ZoneSession.None)
+                .Where(p => !_orphanPlayers.Keys.Contains(p.Eid));
+
+            foreach (var p in playersWithoutSessions)
+            {
+                _orphanPlayers.Add(p.Eid, new PlayerTimeout(p));
+            }
+
+            // Players that are no longer orphaned
+            _orphanPlayers.RemoveRange(_orphanPlayers.Where(o => o.Value.Player.Session != ZoneSession.None).GetKeys().ToArray());
+
+            // Players with Expired timers; Zone assumes the Player has failed to connect and removes them
+            var toRemove = _orphanPlayers.Where(o => o.Value.Expired).ToArray();
+
+            foreach (var o in toRemove)
+            {
+                o.Value.Player.RemoveFromZone();
+                _orphanPlayers.Remove(o.Key);
+                Logger.DebugInfo($"A player w/o session REMOVED: {o.Value.Player}");
+            }
+        }
+
+        private class PlayerTimeout
+        {
+            public Player Player { get; private set; }
+            public bool Expired { get { return _time.Expired; } }
+            private readonly TimeKeeper _time;
+
+            public PlayerTimeout(Player p)
+            {
+                _time = new TimeKeeper(MAX_ORPHAN_TIME);
+                Player = p;
+            }
+        }
+
+    }
+}

--- a/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
+++ b/src/Perpetuum/Zones/SessionlessPlayerTimeout.cs
@@ -12,8 +12,8 @@ namespace Perpetuum.Zones
     /// </summary>
     public class SessionlessPlayerTimeout
     {
-        private static readonly TimeSpan MAX_ORPHAN_TIME = TimeSpan.FromMinutes(2);
-        private static readonly TimeSpan UPDATE_RATE = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan MAX_ORPHAN_TIME = TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan UPDATE_RATE = TimeSpan.FromMinutes(1.5);
         private readonly IZone _zone;
         private IEnumerable<PlayerTimeout> _orphanPlayers;
 

--- a/src/Perpetuum/Zones/ZoneSession.cs
+++ b/src/Perpetuum/Zones/ZoneSession.cs
@@ -264,6 +264,7 @@ namespace Perpetuum.Zones
                 // nincs kint a terepen ezert betoltjuk
                 player = Player.LoadPlayerAndAddToZone(_zone, character);
             }
+
             var session = player.Session as ZoneSession;
             session?.OnStopped();
 
@@ -272,7 +273,7 @@ namespace Perpetuum.Zones
 
             _weatherMonitor = Observer<Packet>.Create(OnWeatherUpdated);
             _zone.Weather.Subscribe(_weatherMonitor);
-            
+
             _terrainUpdateNotifier = CreateTerrainNotifier(player);
 
             player.SetSession(this);

--- a/src/Perpetuum/Zones/ZoneSession.cs
+++ b/src/Perpetuum/Zones/ZoneSession.cs
@@ -249,9 +249,6 @@ namespace Perpetuum.Zones
 
         private void HandleAuth(Packet packet)
         {
-            // TODO: any failure, exception, or network disconnect between when the player was added to zone, and this finalizing step will create a orphaned player on the zone
-            //throw new Exception("TODO SIMULATE NETWORK FAIL");
-
             packet.ReadInt(); // mar nem kell
             var count = (int)(packet.Length - packet.Position) - sizeof(long);
             var encrypted = packet.ReadBytes(count);

--- a/src/Perpetuum/Zones/ZoneSession.cs
+++ b/src/Perpetuum/Zones/ZoneSession.cs
@@ -249,6 +249,9 @@ namespace Perpetuum.Zones
 
         private void HandleAuth(Packet packet)
         {
+            // TODO: any failure, exception, or network disconnect between when the player was added to zone, and this finalizing step will create a orphaned player on the zone
+            //throw new Exception("TODO SIMULATE NETWORK FAIL");
+
             packet.ReadInt(); // mar nem kell
             var count = (int)(packet.Length - packet.Position) - sizeof(long);
             var encrypted = packet.ReadBytes(count);
@@ -264,7 +267,6 @@ namespace Perpetuum.Zones
                 // nincs kint a terepen ezert betoltjuk
                 player = Player.LoadPlayerAndAddToZone(_zone, character);
             }
-
             var session = player.Session as ZoneSession;
             session?.OnStopped();
 

--- a/src/Perpetuum/Zones/ZoneSession.cs
+++ b/src/Perpetuum/Zones/ZoneSession.cs
@@ -273,7 +273,7 @@ namespace Perpetuum.Zones
 
             _weatherMonitor = Observer<Packet>.Create(OnWeatherUpdated);
             _zone.Weather.Subscribe(_weatherMonitor);
-
+            
             _terrainUpdateNotifier = CreateTerrainNotifier(player);
 
             player.SetSession(this);


### PR DESCRIPTION
Attempts to Fix: https://github.com/OpenPerpetuum/OP-Project/issues/109

This addresses at least one issue where players are connected to the server but lose their connection when switching to a new zone socket.  
This happens because when the player is in terminal and undocks, the server loads their player-robot on zone, but the client still has to send a final "Auth" packet when the client successfully loads the zone.  Until the auth-packet is received the ZoneSession on Player in Zone is null (or ZoneSession.None)!
Because a number of things could prevent the client sending Auth (zone load fails, crash, network issue) the player will linger on the zone indefinitely.  All account logoff, and character deselection will not propagate to this orphan player.

The server *has* to wait on the client to send auth to the zone socket, so we have no way to reason about if we are just waiting, or if they truly have dropped connection.

Thus this is just a timeout strategy at the zone level to deal with the issue.