### PR TITLE
Threat adding fix

### DIFF
--- a/src/Perpetuum/Modules/EffectModules/SensorDampenerModule.cs
+++ b/src/Perpetuum/Modules/EffectModules/SensorDampenerModule.cs
@@ -45,7 +45,7 @@ namespace Perpetuum.Modules.EffectModules
 
         protected override void OnApplyingEffect(Unit target)
         {
-            target.AddThreat(ParentRobot, new Threat(ThreatType.Debuff, Threat.SENSOR_DAMPENER));
+            target.AddThreat(ParentRobot, new Threat(ThreatType.Ewar, Threat.SENSOR_DAMPENER));
         }
 
         protected override void SetupEffect(EffectBuilder effectBuilder)

--- a/src/Perpetuum/Modules/EnergyNeutralizerModule.cs
+++ b/src/Perpetuum/Modules/EnergyNeutralizerModule.cs
@@ -48,7 +48,8 @@ namespace Perpetuum.Modules
                 coreNeutralizedDone = Math.Abs(core - unitLock.Target.Core);
 
                 unitLock.Target.OnCombatEvent(ParentRobot, new EnergyDispersionEventArgs(coreNeutralizedDone));
-                unitLock.Target.AddThreat(ParentRobot,new Threat(ThreatType.Undefined, coreNeutralizedDone / 2));
+                var threatValue = (coreNeutralizedDone / 2) + 1;
+                unitLock.Target.AddThreat(ParentRobot, new Threat(ThreatType.EnWar, threatValue));
             }
 
             var packet = new CombatLogPacket(CombatLogType.EnergyNeutralize, unitLock.Target, ParentRobot, this);

--- a/src/Perpetuum/Modules/EnergyVampireModule.cs
+++ b/src/Perpetuum/Modules/EnergyVampireModule.cs
@@ -57,7 +57,7 @@ namespace Perpetuum.Modules
                 ParentRobot.Core += coreNeutralized;
                 coreTransfered = Math.Abs(core - ParentRobot.Core);
 
-                unitLock.Target.AddThreat(ParentRobot,new Threat(ThreatType.Undefined,coreTransfered));
+                unitLock.Target.AddThreat(ParentRobot, new Threat(ThreatType.EnWar, coreTransfered + 1));
             }
 
             var packet = new CombatLogPacket(CombatLogType.EnergyVampire, unitLock.Target, ParentRobot, this);

--- a/src/Perpetuum/Modules/SensorJammerModule.cs
+++ b/src/Perpetuum/Modules/SensorJammerModule.cs
@@ -26,8 +26,6 @@ namespace Perpetuum.Modules
                 base.AcceptVisitor(visitor);
         }
 
-        private const double THREAT_SENSOR_JAMMER = 75.0;
-
         protected override void OnAction()
         {
             var unitLock = GetLock().ThrowIfNotType<UnitLock>(ErrorCodes.InvalidLockType);
@@ -40,7 +38,7 @@ namespace Perpetuum.Modules
             if (success)
             {
                 robot.ResetLocks();
-                robot.AddThreat(ParentRobot, new Threat(ThreatType.Undefined, THREAT_SENSOR_JAMMER));
+                robot.AddThreat(ParentRobot, new Threat(ThreatType.Ewar, Threat.SENSOR_DAMPENER));
             }
 
             var packet = new CombatLogPacket(CombatLogType.Jammer, robot,ParentRobot,this);

--- a/src/Perpetuum/Zones/Locking/LockHandler.cs
+++ b/src/Perpetuum/Zones/Locking/LockHandler.cs
@@ -43,7 +43,7 @@ namespace Perpetuum.Zones.Locking
         }
 
         public double MaxTargetingRange { get { return _maxTargetingRange.Value; } }
-        private int MaxLockedTargets { get { return 1; } }//{ get { return (int) _maxLockedTargets.Value; } }
+        private int MaxLockedTargets { get { return (int) _maxLockedTargets.Value; } }
         public int Count { get { return _locks.Count; } }
 
         public List<Lock> Locks

--- a/src/Perpetuum/Zones/Locking/LockHandler.cs
+++ b/src/Perpetuum/Zones/Locking/LockHandler.cs
@@ -43,7 +43,7 @@ namespace Perpetuum.Zones.Locking
         }
 
         public double MaxTargetingRange { get { return _maxTargetingRange.Value; } }
-        private int MaxLockedTargets { get { return (int) _maxLockedTargets.Value; } }
+        private int MaxLockedTargets { get { return 1; } }//{ get { return (int) _maxLockedTargets.Value; } }
         public int Count { get { return _locks.Count; } }
 
         public List<Lock> Locks

--- a/src/Perpetuum/Zones/NpcSystem/Npc.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Npc.cs
@@ -568,35 +568,7 @@ namespace Perpetuum.Zones.NpcSystem
         }
     }
 
-    public class PsuedoThreat
-    {
-        private TimeSpan _lastUpdated = TimeSpan.Zero;
-        private TimeSpan Expiration = TimeSpan.FromMinutes(1);
-
-        public PsuedoThreat(Unit unit)
-        {
-            Unit = unit;
-        }
-
-        public Unit Unit { get; }
-
-        public bool IsExpired
-        {
-            get { return _lastUpdated > Expiration; }
-        }
-
-        public void RefreshThreat()
-        {
-            _lastUpdated = TimeSpan.Zero;
-        }
-
-        public void Update(TimeSpan time)
-        {
-            _lastUpdated += time;
-        }
-    }
-
-    public class Npc : Creature,ITaggable
+    public class Npc : Creature, ITaggable
     {
         private readonly TagHelper _tagHelper;
         private const double CALL_FOR_HELP_ARMOR_THRESHOLD = 0.2;
@@ -604,8 +576,7 @@ namespace Perpetuum.Zones.NpcSystem
         private object _bestCombatRange;
         private TimeSpan _lastHelpCalled;
         private readonly EventListenerService _eventChannel;
-        private List<PsuedoThreat> PseudoThreats;
-        private object PseudoLock = new Object();
+        private readonly IPseudoThreatManager _pseudoThreatManager;
 
         public Npc(TagHelper tagHelper, EventListenerService eventChannel)
         {
@@ -613,7 +584,7 @@ namespace Perpetuum.Zones.NpcSystem
             _tagHelper = tagHelper;
             _threatManager = new ThreatManager();
             AI = new StackFSM();
-            PseudoThreats = new List<PsuedoThreat>();
+            _pseudoThreatManager = new PseudoThreatManager();
         }
 
         public NpcBehavior Behavior { get; set; }
@@ -671,7 +642,7 @@ namespace Perpetuum.Zones.NpcSystem
             return TagHelper.GetTagger(this);
         }
 
-        public void AddThreat(Unit hostile, Threat threat,bool spreadToGroup)
+        public void AddThreat(Unit hostile, Threat threat, bool spreadToGroup)
         {
             if (IsBoss() && hostile.IsPlayer())
             {
@@ -679,15 +650,7 @@ namespace Perpetuum.Zones.NpcSystem
             }
             _threatManager.GetOrAddHostile(hostile).AddThreat(threat);
 
-            var PseudoThreat = PseudoThreats.Where(x => x.Unit == hostile).FirstOrDefault();
-            if (PseudoThreat != null)
-            {
-                lock (PseudoLock)
-                {
-                    PseudoThreats.Remove(PseudoThreat);
-                    Logger.DebugInfo(" Removed " + PseudoThreat.ToString());
-                }
-            }
+            RemovePseudoThreat(hostile);
 
             if (!spreadToGroup)
                 return;
@@ -708,19 +671,17 @@ namespace Perpetuum.Zones.NpcSystem
 
         public void AddPseudoThreat(Unit hostile)
         {
-            lock (PseudoLock)
-            {
-                PseudoThreats.Add(new PsuedoThreat(hostile));
-            }
+            _pseudoThreatManager.AddOrRefreshExisting(hostile);
         }
 
         private void UpdatePseudoThreats(TimeSpan time)
         {
-            lock (PseudoLock)
-            {
-                PseudoThreats.ForEach(threat => threat.Update(time));
-                PseudoThreats.RemoveAll(threat => threat.IsExpired);
-            }
+            _pseudoThreatManager.Update(time);
+        }
+
+        private void RemovePseudoThreat(Unit hostile)
+        {
+            _pseudoThreatManager.Remove(hostile);
         }
 
         public override void AcceptVisitor(IEntityVisitor visitor)
@@ -865,19 +826,16 @@ namespace Perpetuum.Zones.NpcSystem
 
                 if (ep > 0)
                 {
+                    var awardedPlayers = new List<Unit>();
                     foreach (var hostile in ThreatManager.Hostiles)
                     {
-                        var hostilePlayer = zone.ToPlayerOrGetOwnerPlayer(hostile.unit);
+                        var playerUnit = hostile.unit;
+                        var hostilePlayer = zone.ToPlayerOrGetOwnerPlayer(playerUnit);
                         hostilePlayer?.Character.AddExtensionPointsBoostAndLog(EpForActivityType.Npc, ep);
+                        awardedPlayers.Add(playerUnit);
                     }
 
-                    // same as above, but add half EP for players that were out of range of the NPC.
-                    var psuedoHostiles = PseudoThreats.Where(p => !ThreatManager.Contains(p.Unit));
-                    foreach (var hostile in psuedoHostiles)
-                    {
-                        var hostilePlayer = zone.ToPlayerOrGetOwnerPlayer(hostile.Unit);
-                        hostilePlayer?.Character.AddExtensionPointsBoostAndLog(EpForActivityType.Npc, ep / 2);
-                    }
+                    _pseudoThreatManager.AwardPseudoThreats(awardedPlayers, zone, ep);
                 }
 
                 scope.Complete();

--- a/src/Perpetuum/Zones/NpcSystem/Npc.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Npc.cs
@@ -1044,8 +1044,7 @@ namespace Perpetuum.Zones.NpcSystem
         /// <returns>If the target can be a threat</returns>
         public bool CanAddThreatTo(Unit target, Threat threat)
         {
-            var hasThreat = _threatManager.Contains(target);
-            if (hasThreat)
+            if (_threatManager.Contains(target))
                 return true;
 
             switch (Behavior.Type)
@@ -1054,20 +1053,9 @@ namespace Perpetuum.Zones.NpcSystem
                     return false;
                 case NpcBehaviorType.Neutral:
                     {
-                        switch (threat.type)
-                        {
-                            case ThreatType.Undefined:
-                                return false;
-                            default:
-                                return true;
-                        }
-                    }
-                case NpcBehaviorType.Aggressive:
-                    {
-                        return IsInAggroRange(target);
+                        return threat.type != ThreatType.Undefined;
                     }
             }
-
             return IsInAggroRange(target);
         }
 

--- a/src/Perpetuum/Zones/NpcSystem/Npc.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Npc.cs
@@ -1033,46 +1033,42 @@ namespace Perpetuum.Zones.NpcSystem
             return true;
         }
 
-        public bool CanAddThreatTo(Unit target,Threat threat)
+        /// <summary>
+        /// This determines if threat can be added to a target based on the following:
+        ///  - Is the target already on the threat manager
+        ///  - Or is the npc aggressive and within aggrorange
+        ///  - Or is the npc non-passive and the Threat is of some defined type
+        /// </summary>
+        /// <param name="target">Unit target</param>
+        /// <param name="threat">Threat threat</param>
+        /// <returns>If the target can be a threat</returns>
+        public bool CanAddThreatTo(Unit target, Threat threat)
         {
             var hasThreat = _threatManager.Contains(target);
             if (hasThreat)
                 return true;
-
-            var check = false;
 
             switch (Behavior.Type)
             {
                 case NpcBehaviorType.Passive:
                     return false;
                 case NpcBehaviorType.Neutral:
-                {
-                    switch (threat.type)
                     {
-                        case ThreatType.Direct:
+                        switch (threat.type)
                         {
-                            // itt nincs aggrorange,mehet mindig
-                            return true;
-                        }
-
-                        case ThreatType.Debuff:
-                        case ThreatType.Support:
-                        case ThreatType.Lock:
-                        {
-                            check = true;
-                            break;
+                            case ThreatType.Undefined:
+                                return false;
+                            default:
+                                return true;
                         }
                     }
-                    break;
-                }
                 case NpcBehaviorType.Aggressive:
-                {
-                    check = true;
-                    break;
-                }
+                    {
+                        return IsInAggroRange(target);
+                    }
             }
 
-            return check && IsInAggroRange(target);
+            return IsInAggroRange(target);
         }
 
         private void AddBodyPullThreat(Unit enemy)

--- a/src/Perpetuum/Zones/NpcSystem/ThreatManager.cs
+++ b/src/Perpetuum/Zones/NpcSystem/ThreatManager.cs
@@ -16,7 +16,9 @@ namespace Perpetuum.Zones.NpcSystem
         Lock,
         Buff,
         Debuff,
-        Direct
+        Direct,
+        EnWar,
+        Ewar
     }
 
     public struct Threat

--- a/src/Perpetuum/Zones/NpcSystem/ThreatManager.cs
+++ b/src/Perpetuum/Zones/NpcSystem/ThreatManager.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using Perpetuum.Comparers;
 using Perpetuum.Timers;
 using Perpetuum.Units;
 
@@ -186,6 +188,117 @@ namespace Perpetuum.Zones.NpcSystem
             sb.AppendLine("============================");
 
             return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Manager of PseudoThreats
+    /// Processes and manages an internal collection of players aggressive to an npc
+    /// but not on the npc's ThreatManager.
+    /// For awarding players a portion of the total ep reward.
+    /// </summary>
+    public interface IPseudoThreatManager
+    {
+        void Update(TimeSpan time);
+        void AddOrRefreshExisting(Unit hostile);
+        void Remove(Unit hostile);
+        void AwardPseudoThreats(List<Unit> alreadyAwarded, IZone zone, int ep);
+    }
+
+
+    public class PseudoThreatManager : IPseudoThreatManager
+    {
+        private readonly List<PseudoThreat> _pseudoThreats;
+        private readonly object _lock;
+
+        public PseudoThreatManager()
+        {
+            _pseudoThreats = new List<PseudoThreat>();
+            _lock = new object();
+        }
+
+        public void AwardPseudoThreats(List<Unit> alreadyAwarded, IZone zone, int ep)
+        {
+            var pseudoHostileUnits = new List<Unit>();
+            lock (_lock)
+            {
+                pseudoHostileUnits = _pseudoThreats.Select(p => p.Unit).Except(alreadyAwarded, new EntityComparer()).Cast<Unit>().ToList();
+            }
+            foreach (var unit in pseudoHostileUnits)
+            {
+                var hostilePlayer = zone.ToPlayerOrGetOwnerPlayer(unit);
+                hostilePlayer?.Character.AddExtensionPointsBoostAndLog(EpForActivityType.Npc, ep / 2);
+            }
+        }
+
+        public void AddOrRefreshExisting(Unit hostile)
+        {
+            lock (_lock)
+            {
+                var existing = _pseudoThreats.Where(x => x.Unit == hostile).FirstOrDefault();
+                if (existing != null)
+                {
+                    existing.RefreshThreat();
+                    return;
+                }
+                _pseudoThreats.Add(new PseudoThreat(hostile));
+            }
+        }
+
+        public void Remove(Unit hostile)
+        {
+            lock(_lock)
+                _pseudoThreats.RemoveAll(x => x.Unit == hostile);
+        }
+
+        public void Update(TimeSpan time)
+        {
+            lock (_lock)
+            {
+                foreach (var threat in _pseudoThreats)
+                {
+                    threat.Update(time);
+                }
+                CleanExpiredThreats();
+            }
+        }
+
+        private void CleanExpiredThreats()
+        {
+            _pseudoThreats.RemoveAll(threat => threat.IsExpired);
+        }
+    }
+
+
+    /// <summary>
+    /// An expirable record of a player that is aggressing an npc but the npc is
+    /// not capable of attacking back (removed from the ThreatManager)
+    /// </summary>
+    public class PseudoThreat
+    {
+        private TimeSpan _lastUpdated = TimeSpan.Zero;
+        private TimeSpan Expiration = TimeSpan.FromMinutes(1);
+
+        public PseudoThreat(Unit unit)
+        {
+            Unit = unit;
+        }
+
+        public Unit Unit { get; }
+
+        public bool IsExpired
+        {
+            get { return _lastUpdated > Expiration; }
+        }
+
+        public void RefreshThreat()
+        {
+            _lastUpdated = TimeSpan.Zero;
+        }
+
+        public void Update(TimeSpan time)
+        {
+            _lastUpdated += time;
         }
     }
 }


### PR DESCRIPTION
Fixes: #200 
This is *very* tricky, and presents only in extraordinary situations only with players using only specific types of modules against the npc.

This is before threats are added to the threatmanager at all, and therefore are not part of the pseudo-aggro solution from before.
These threats are just not added because they are filtered out of this gating conditional method that checked:
 - Was the unit already on the threatmanager
 - Is the unit close to an aggressive npc
 - or is the type of threat of some particular types: (which included some but not all modules because of some neglected cases using ThreatType.Undefined) AND within 300m?! (why?)

Typically, when you lock an NPC, that adds you to the threatmanager, until it doesn't and removes you for distance or some other condition where it can't actively attack you back (hence the psuedo-aggro fix).

So now the player has already been added, then dropped, from the threatmanager, and expired off the pseudoaggro list.
Yet they are still using Enwar/ewar modules aggressively against the npc from a distance.

This is where we see reports around Enwar pilots not getting any EP from killing bosses, because they sit at range, shoot an unsupported threat-adding type, and they have been doing so for long enough to no longer be on the threatmanager or psuedothreat manager.


The fix is to actively support these types, and not gate them with an arbitrary range.
