### PR TITLE
First commit for rally terminals (field terminals with no assignments)

### DIFF
--- a/src/Perpetuum.ExportedTypes/DefinitionNames.cs
+++ b/src/Perpetuum.ExportedTypes/DefinitionNames.cs
@@ -970,6 +970,7 @@ namespace Perpetuum.ExportedTypes
  		 public const string FIELD_CONTAINER = "def_field_container";
  		 public const string FIELD_TERMINAL_NUIMQOL = "def_field_terminal_nuimqol";
  		 public const string FIELD_TERMINAL_PELISTAL = "def_field_terminal_pelistal";
+         public const string FIELD_TERMINAL_RALLY = "def_field_terminal_rally";
  		 public const string FIELD_TERMINAL_THELODICA = "def_field_terminal_thelodica";
  		 public const string GALATROY_BOT = "def_galatroy_bot";
  		 public const string GALATROY_CHASSIS = "def_galatroy_chassis";

--- a/src/Perpetuum.RequestHandlers/Missions/MissionGetOptions.cs
+++ b/src/Perpetuum.RequestHandlers/Missions/MissionGetOptions.cs
@@ -13,7 +13,7 @@ namespace Perpetuum.RequestHandlers.Missions
         private readonly MissionDataCache _missionDataCache;
         private readonly IEntityRepository _entityRepository;
 
-        public MissionGetOptions(MissionProcessor missionProcessor,MissionDataCache missionDataCache, IEntityRepository entityRepository)
+        public MissionGetOptions(MissionProcessor missionProcessor, MissionDataCache missionDataCache, IEntityRepository entityRepository)
         {
             _missionProcessor = missionProcessor;
             _missionDataCache = missionDataCache;
@@ -25,31 +25,24 @@ namespace Perpetuum.RequestHandlers.Missions
             var character = request.Session.Character;
             long locationEid;
 
-            FieldTerminal terminal = null;
-
             if (character.IsDocked)
             {
                 //the base we the player is docked
                 locationEid = character.CurrentDockingBaseEid;
-
             }
             else
             {
                 //use the optional parameter
                 locationEid = request.Data.GetOrDefault<long>(k.eid);
-
                 // Load Entity to see if it's a custom field terminal
-                terminal = (FieldTerminal)_entityRepository.Load(locationEid).ThrowIfNull(ErrorCodes.TargetNotFound);
+                var terminal = _entityRepository.Load(locationEid)
+                    .ThrowIfNull(ErrorCodes.TargetNotFound)
+                    .ThrowIfNotType<FieldTerminal>(ErrorCodes.MissionNotAvailable);
+                // Don't show missions for rally terminals
+                terminal.ED.Name.ThrowIfEqual(DefinitionNames.FIELD_TERMINAL_RALLY, ErrorCodes.MissionNotAvailable);
             }
-
-            // Don't show missions for rally terminals
-            if (terminal != null && terminal.ED.Name == DefinitionNames.FIELD_TERMINAL_RALLY) {
-                throw PerpetuumException.Create(ErrorCodes.MissionNotAvailable);
-            } else {
-                var location = _missionDataCache.GetLocationByEid(locationEid).ThrowIfNull(ErrorCodes.ItemNotFound);
-                _missionProcessor.GetOptionsByRequest(character, location);
-            }
-            
+            var location = _missionDataCache.GetLocationByEid(locationEid).ThrowIfNull(ErrorCodes.ItemNotFound);
+            _missionProcessor.GetOptionsByRequest(character, location);
         }
     }
 }

--- a/src/Perpetuum.RequestHandlers/Missions/MissionGetOptions.cs
+++ b/src/Perpetuum.RequestHandlers/Missions/MissionGetOptions.cs
@@ -1,6 +1,9 @@
-﻿using Perpetuum.Host.Requests;
+﻿using Perpetuum.EntityFramework;
+using Perpetuum.ExportedTypes;
+using Perpetuum.Host.Requests;
 using Perpetuum.Services.MissionEngine.MissionDataCacheObjects;
 using Perpetuum.Services.MissionEngine.MissionProcessorObjects;
+using Perpetuum.Units.FieldTerminals;
 
 namespace Perpetuum.RequestHandlers.Missions
 {
@@ -8,11 +11,13 @@ namespace Perpetuum.RequestHandlers.Missions
     {
         private readonly MissionProcessor _missionProcessor;
         private readonly MissionDataCache _missionDataCache;
+        private readonly IEntityRepository _entityRepository;
 
-        public MissionGetOptions(MissionProcessor missionProcessor,MissionDataCache missionDataCache)
+        public MissionGetOptions(MissionProcessor missionProcessor,MissionDataCache missionDataCache, IEntityRepository entityRepository)
         {
             _missionProcessor = missionProcessor;
             _missionDataCache = missionDataCache;
+            _entityRepository = entityRepository;
         }
 
         public void HandleRequest(IRequest request)
@@ -20,19 +25,31 @@ namespace Perpetuum.RequestHandlers.Missions
             var character = request.Session.Character;
             long locationEid;
 
+            FieldTerminal terminal = null;
+
             if (character.IsDocked)
             {
                 //the base we the player is docked
                 locationEid = character.CurrentDockingBaseEid;
+
             }
             else
             {
                 //use the optional parameter
                 locationEid = request.Data.GetOrDefault<long>(k.eid);
+
+                // Load Entity to see if it's a custom field terminal
+                terminal = (FieldTerminal)_entityRepository.Load(locationEid).ThrowIfNull(ErrorCodes.TargetNotFound);
             }
 
-            var location = _missionDataCache.GetLocationByEid(locationEid).ThrowIfNull(ErrorCodes.ItemNotFound);
-            _missionProcessor.GetOptionsByRequest(character, location);
+            // Don't show missions for rally terminals
+            if (terminal != null && terminal.ED.Name == DefinitionNames.FIELD_TERMINAL_RALLY) {
+                throw PerpetuumException.Create(ErrorCodes.MissionNotAvailable);
+            } else {
+                var location = _missionDataCache.GetLocationByEid(locationEid).ThrowIfNull(ErrorCodes.ItemNotFound);
+                _missionProcessor.GetOptionsByRequest(character, location);
+            }
+            
         }
     }
 }


### PR DESCRIPTION
Resource server commit:
https://github.com/OpenPerpetuum/OPResource/compare/rally-terminal

OPDB commit:
https://github.com/OpenPerpetuum/OPDB/compare/rally-terminal

I've called it a "Rally Field Terminal" since I understand it's supposed to be like a "rally point". We can rename it if we need to.

If we never plan to have rally terminals in the same zone as regular terminals then we can potentially simplify the `MissionGetOptions.cs` changes to just check the zone, but this probably still requires checking if the zone is a stronghold zone. I feel like this implementation is more complete and prepares us for more options in the future.

This code does nothing to limit the "Active Missions" from being pulled from the server. This is because the existing "Assignments" UI allows the user to deliver or abort the current assignment. The way it exists now, a user can abort or turn in an assignment from another zone - but it does not give the teleport benefit.

![image](https://user-images.githubusercontent.com/6828105/97816874-6c4d5900-1c4d-11eb-9980-09e91a677c37.png)
