### PR TITLE
Plant update bug fix

### DIFF
--- a/src/Perpetuum/Zones/Terrains/NatureCube.cs
+++ b/src/Perpetuum/Zones/Terrains/NatureCube.cs
@@ -456,6 +456,8 @@ namespace Perpetuum.Zones.Terrains
                 var currentAmount = kvp.Value;
 
                 var rule = _zone.Configuration.PlantRules.GetPlantRule(currentPlantType);
+                if (rule == null)
+                    continue;
 
                 if (rule.HasBlockingState)
                 {


### PR DESCRIPTION
Is null when encounters plant that is not in rule set, but is cleared out with later steps.
If it throws in this first check the cube update reverts and no plant updates will continue.