### PR TITLE
Lock/unlock layer command

### DIFF
--- a/src/Perpetuum.RequestHandlers/Zone/ZoneCleanObstacleBlocking.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/ZoneCleanObstacleBlocking.cs
@@ -7,6 +7,7 @@ namespace Perpetuum.RequestHandlers.Zone
     {
         public void HandleRequest(IZoneRequest request)
         {
+            request.Zone.IsLayerEditLocked.ThrowIfTrue(ErrorCodes.TileTerraformProtected);
             request.Zone.Terrain.Blocks.UpdateAll((x, y, bi) =>
             {
                 bi.Obstacle = false;

--- a/src/Perpetuum.RequestHandlers/Zone/ZoneClearLayer.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/ZoneClearLayer.cs
@@ -7,6 +7,7 @@ namespace Perpetuum.RequestHandlers.Zone
     {
         public void HandleRequest(IZoneRequest request)
         {
+            request.Zone.IsLayerEditLocked.ThrowIfTrue(ErrorCodes.TileTerraformProtected);
             var layerName = request.Data.GetOrDefault<string>(k.layerName);
 
             switch (layerName)

--- a/src/Perpetuum.RequestHandlers/Zone/ZoneCreateIsland.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/ZoneCreateIsland.cs
@@ -8,6 +8,7 @@ namespace Perpetuum.RequestHandlers.Zone
     {
         public void HandleRequest(IZoneRequest request)
         {
+            request.Zone.IsLayerEditLocked.ThrowIfTrue(ErrorCodes.TileTerraformProtected);
             var low = request.Data.GetOrDefault<int>(k.low);
             var waterLevel = ZoneConfiguration.WaterLevel;
 

--- a/src/Perpetuum.RequestHandlers/Zone/ZoneDrawRamp.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/ZoneDrawRamp.cs
@@ -28,6 +28,7 @@ namespace Perpetuum.RequestHandlers.Zone
 
             fullBlend = fullBlend.Clamp();
             var zone = request.Zone;
+            zone.IsLayerEditLocked.ThrowIfTrue(ErrorCodes.TileTerraformProtected);
 
             Player player;
             if (zone.TryGetPlayer(request.Session.Character, out player))

--- a/src/Perpetuum.RequestHandlers/Zone/ZoneTerraformTest.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/ZoneTerraformTest.cs
@@ -23,6 +23,7 @@ namespace Perpetuum.RequestHandlers.Zone
 
         public void HandleRequest(IZoneRequest request)
         {
+            request.Zone.IsLayerEditLocked.ThrowIfTrue(ErrorCodes.TileTerraformProtected);
             var character = request.Session.Character;
 
             var player = request.Zone.GetPlayer(character);

--- a/src/Perpetuum/Zones/IZone.cs
+++ b/src/Perpetuum/Zones/IZone.cs
@@ -25,6 +25,7 @@ namespace Perpetuum.Zones
     public interface IZone 
     {
         [NotNull] ZoneConfiguration Configuration { get; }
+        bool IsLayerEditLocked { get; set; }
 
         int Id { get; }
         Size Size { get; }

--- a/src/Perpetuum/Zones/Zone.cs
+++ b/src/Perpetuum/Zones/Zone.cs
@@ -82,9 +82,11 @@ namespace Perpetuum.Zones
         public TcpListener Listener { get; set; }
 
         private readonly SessionlessPlayerTimeout _sessionlessPlayerTimeout;
+        public bool IsLayerEditLocked { get; set; }
 
         protected Zone(ISessionManager sessionManager, IGangManager gangManager)
         {
+            IsLayerEditLocked = true;
             sessionManager.CharacterDeselected += OnCharacterDeselected;
             _gangManager = gangManager;
             _gangManager.GangMemberJoined += OnGangMemberJoined;

--- a/src/Perpetuum/Zones/ZoneSession.cs
+++ b/src/Perpetuum/Zones/ZoneSession.cs
@@ -695,6 +695,7 @@ namespace Perpetuum.Zones
         private void HandleSetLayer(Packet packet)
         {
             _player.Session.AccessLevel.IsAdminOrGm().ThrowIfFalse(ErrorCodes.AccessDenied);
+            _zone.IsLayerEditLocked.ThrowIfTrue(ErrorCodes.TileTerraformProtected);
 
             using (new TerrainUpdateMonitor(_zone))
             {


### PR DESCRIPTION
Set a zone to editable/uneditable by command, where default is no edits allowed.
This will ensure admin operations don't accidentally alter layers that are not the result of natural processes or player terraforming operations. (Only gates admin level commands)

Closes: #268 