### PR TITLE
PMCQ/session disposal/reinit fix

### DIFF
--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -266,8 +266,7 @@ namespace Perpetuum.Players
             Session.SendPacket(ExitPacketBuilder);
             zone.SendPacketToGang(Gang, new GangUpdatePacketBuilder(Visibility.Invisible, this));
 
-            _check.Stop();
-            _check.Dispose();
+            _check.StopAndDispose();
 
             if (!States.LocalTeleport)
                 Session.Stop();

--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -35,7 +35,6 @@ using Perpetuum.Zones.Blobs.BlobEmitters;
 using Perpetuum.Zones.CombatLogs;
 using Perpetuum.Zones.DamageProcessors;
 using Perpetuum.Zones.Effects;
-using Perpetuum.Zones.Effects.ZoneEffects;
 using Perpetuum.Zones.Finders;
 using Perpetuum.Zones.Finders.PositionFinders;
 using Perpetuum.Zones.Locking;
@@ -267,15 +266,11 @@ namespace Perpetuum.Players
             Session.SendPacket(ExitPacketBuilder);
             zone.SendPacketToGang(Gang, new GangUpdatePacketBuilder(Visibility.Invisible, this));
 
-            Task.Run(() =>
-            {
-                _check.Stop();
-                _check.Dispose();
-            }).ContinueWith(t =>
-            {
-                if (!States.LocalTeleport)
-                    Session.Stop();
-            });
+            _check.Stop();
+            _check.Dispose();
+
+            if (!States.LocalTeleport)
+                Session.Stop();
 
             base.OnRemovedFromZone(zone);
         }

--- a/src/Perpetuum/Players/PlayerMoveChecker.cs
+++ b/src/Perpetuum/Players/PlayerMoveChecker.cs
@@ -49,7 +49,24 @@ namespace Perpetuum.Players
                 _task.Start();
         }
 
-        public bool Stop()
+        public void StopAndDispose()
+        {
+            try
+            {
+                if (!Stop())
+                {
+                    Logger.Warning("PMCQ failed to join Task under timeout");
+                }
+                Dispose();
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning("PMCQ errored on cleanup");
+                Logger.Exception(ex);
+            }
+        }
+
+        private bool Stop()
         {
             if (!IsCanceled)
                 _tokenSrc.Cancel();

--- a/src/Perpetuum/Players/PlayerMoveChecker.cs
+++ b/src/Perpetuum/Players/PlayerMoveChecker.cs
@@ -11,6 +11,7 @@ namespace Perpetuum.Players
 {
     public class PlayerMoveCheckQueue : Disposable
     {
+        private readonly TimeSpan MAX_TIMEOUT = TimeSpan.FromSeconds(1);
         private readonly Task _task;
         private readonly CancellationTokenSource _tokenSrc;
         private CancellationToken _ct;
@@ -56,7 +57,8 @@ namespace Perpetuum.Players
             if (!IsCompleted)
                 _movesToReview.CompleteAdding();
 
-            _task.Wait();
+            _movesToReview.Clear();
+            _task.Wait(MAX_TIMEOUT);
         }
 
         public void EnqueueMove(Position target)

--- a/src/Perpetuum/Players/PlayerMoveChecker.cs
+++ b/src/Perpetuum/Players/PlayerMoveChecker.cs
@@ -11,7 +11,7 @@ namespace Perpetuum.Players
 {
     public class PlayerMoveCheckQueue : Disposable
     {
-        private readonly TimeSpan MAX_TIMEOUT = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan MAX_TIMEOUT = TimeSpan.FromSeconds(2);
         private readonly Task _task;
         private readonly CancellationTokenSource _tokenSrc;
         private CancellationToken _ct;
@@ -49,7 +49,7 @@ namespace Perpetuum.Players
                 _task.Start();
         }
 
-        public void Stop()
+        public bool Stop()
         {
             if (!IsCanceled)
                 _tokenSrc.Cancel();
@@ -58,7 +58,7 @@ namespace Perpetuum.Players
                 _movesToReview.CompleteAdding();
 
             _movesToReview.Clear();
-            _task.Wait(MAX_TIMEOUT);
+            return _task.Wait(MAX_TIMEOUT);
         }
 
         public void EnqueueMove(Position target)


### PR DESCRIPTION
Closes: https://github.com/OpenPerpetuum/PerpetuumServer/issues/265

These need to happen *strictly* before they are reinitialized otherwise you get a disposed PMCQ on a new zone/location and/or a *removed* ZoneSession reference from the Zone (but the session is still on the player! which allows them to move about and operate normally, but without zone.update calls!)

Task.Wait(..) blocks, which is why we put it in the task, but its adding 20-30ms on my local cpu running this inline.  I put in a timeout just in case it hangs before we dispose.