### PR TITLE
Groundtype: render and clear current state

### DIFF
--- a/src/Perpetuum.RequestHandlers/Zone/StatsMapDrawing/ZoneDrawStatMap.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/StatsMapDrawing/ZoneDrawStatMap.cs
@@ -64,6 +64,7 @@ namespace Perpetuum.RequestHandlers.Zone.StatsMapDrawing
             RegisterCreator("displayspots", DisplaySpots);
             RegisterCreator("worstspots",DrawWorstSpotsMap);
             RegisterCreator("alltargets", DrawAllTargetsOnZone);
+            RegisterCreator(k.groundType, CreateGroundTypeMap);
         }
 
         private void RegisterCreator(string type,Func<IRequest,Bitmap> bitmapFactory)
@@ -638,6 +639,23 @@ namespace Perpetuum.RequestHandlers.Zone.StatsMapDrawing
                 var control = _zone.Terrain.Controls.GetValue(x, y);
                 var c = (int)control.Flags;
                 bmp.SetPixel(x, y, Color.FromArgb(c,c,c));
+            });
+        }
+
+        private Bitmap CreateGroundTypeMap()
+        {
+            var numGroundTypes = Enum.GetNames(typeof(GroundType)).Length;
+            var colors = new Color[numGroundTypes];
+            var random = new Random(numGroundTypes);
+            for (var i = 0; i < colors.Length; i++)
+            {
+                colors[i] = Color.FromArgb(random.Next(255), random.Next(255), random.Next(255));
+            }
+            return _zone.CreateBitmap().ForEach((bmp, x, y) =>
+            {
+                var groundType = _zone.Terrain.Plants.GetValue(x, y).groundType;
+                var c = colors[((int)groundType).Clamp(0, numGroundTypes - 1)];
+                bmp.SetPixel(x, y, c);
             });
         }
 

--- a/src/Perpetuum.RequestHandlers/Zone/ZoneClearLayer.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/ZoneClearLayer.cs
@@ -12,6 +12,13 @@ namespace Perpetuum.RequestHandlers.Zone
 
             switch (layerName)
             {
+                case k.groundType:
+                    request.Zone.Terrain.Plants.UpdateAll((x, y, pi) =>
+                    {
+                        pi.ClearGroundType();
+                        return pi;
+                    });
+                    break;
                 case k.plants:
                     request.Zone.Terrain.Plants.UpdateAll((x, y, pi) =>
                     {

--- a/src/Perpetuum/Keywords.cs
+++ b/src/Perpetuum/Keywords.cs
@@ -429,6 +429,7 @@ namespace Perpetuum
         public const string group = "group";
         public const string groupEID = "groupEID";
         public const string ground = "ground";
+        public const string groundType = "groundType";
         public const string growRate = "growRate";
         public const string guid = "guid";
         public const string hangar = "hangar";

--- a/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandData.cs
+++ b/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandData.cs
@@ -14,7 +14,7 @@ namespace Perpetuum.Services.Channels.ChatCommands
             public CommandArgs(string[] commandArray)
             {
                 Name = commandArray[0].Substring(1).ToLower().Trim();
-                Args = commandArray.Skip(1).ToArray();
+                Args = commandArray.Skip(1).Select(s => s.Trim()).ToArray();
             }
         }
 

--- a/src/Perpetuum/Zones/Terrains/GroundType.cs
+++ b/src/Perpetuum/Zones/Terrains/GroundType.cs
@@ -26,6 +26,7 @@
         type9,
         type10,
         type11,
+        undefined
     }
 
 }

--- a/src/Perpetuum/Zones/Terrains/Materials/Plants/PlantInfo.cs
+++ b/src/Perpetuum/Zones/Terrains/Materials/Plants/PlantInfo.cs
@@ -23,6 +23,11 @@ namespace Perpetuum.Zones.Terrains.Materials.Plants
             material = 0;
         }
 
+        public void ClearGroundType()
+        {
+            groundType = GroundType.undefined;
+        }
+
         public void SetPlant(byte newState, PlantType newPlantType)
         {
             state = newState;


### PR DESCRIPTION
Groundtype is a mysterious byte on the plant layer that governs how plantrules map plants to certain areas.
It appears most zones are just a noise map of some particular set of these, related to faction most likely.
One can wipe a groundType layer with the brush, but a "clear" option is a good way to make sure you have a fresh canvas, as groundtype doesn't render in the client in a meaningful way.  Hence the bitmap output.

Closes: https://github.com/OpenPerpetuum/PerpetuumServer/issues/271