### PR TITLE
Production cost: by category and/or tech and/or techtype

### DIFF
--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -1641,6 +1641,7 @@ namespace Perpetuum.Bootstrapper
             _builder.RegisterType<ReprocessSessionMember>();
             _builder.RegisterType<ReprocessSession>();
 
+            _builder.RegisterType<ProductionCostReader>().As<IProductionCostReader>();
             _builder.RegisterType<ProductionDataAccess>().OnActivated(e =>
             {
                 e.Instance.Init();

--- a/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
+++ b/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
@@ -227,7 +227,7 @@ namespace Perpetuum.Services.ProductionEngine.Facilities
         public virtual double GetPricePerSecond(int targetDefinition)
         {
             var mod = ProductionDataAccess.GetProductionPriceModifier(targetDefinition);
-            return GetPricePerSecond() * mod.Clamp(1,10);
+            return GetPricePerSecond() * mod.Clamp(1, 10);
         }
 
         public virtual double GetPricePerSecond()

--- a/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
+++ b/src/Perpetuum/Services/ProductionEngine/Facilities/ProductionFacility.cs
@@ -226,9 +226,8 @@ namespace Perpetuum.Services.ProductionEngine.Facilities
         //Overload method for price/sec
         public virtual double GetPricePerSecond(int targetDefinition)
         {
-            var mod = Math.Max(1, ProductionDataAccess.GetProductionPriceModifier(targetDefinition));
-            mod = Math.Min(10, mod);
-            return GetPricePerSecond() * mod;
+            var mod = ProductionDataAccess.GetProductionPriceModifier(targetDefinition);
+            return GetPricePerSecond() * mod.Clamp(1,10);
         }
 
         public virtual double GetPricePerSecond()

--- a/src/Perpetuum/Services/ProductionEngine/IProductionDataAccess.cs
+++ b/src/Perpetuum/Services/ProductionEngine/IProductionDataAccess.cs
@@ -11,7 +11,7 @@ namespace Perpetuum.Services.ProductionEngine
         IDictionary<int, ItemResearchLevel> ResearchLevels { get; }
         ILookup<int, ProductionComponent> ProductionComponents { get; }
         IDictionary<CategoryFlags, double> ProductionDurations { get; }
-        IDictionary<int, ProductionCost> ProductionCost { get; }
+        IDictionary<int, double> ProductionCost { get; }
         IDictionary<int, CalibrationDefault> CalibrationDefaults { get; }
 
         ProductionDecalibration GetDecalibration(int targetDefinition);

--- a/src/Perpetuum/Services/ProductionEngine/IProductionDataAccess.cs
+++ b/src/Perpetuum/Services/ProductionEngine/IProductionDataAccess.cs
@@ -11,8 +11,7 @@ namespace Perpetuum.Services.ProductionEngine
         IDictionary<int, ItemResearchLevel> ResearchLevels { get; }
         ILookup<int, ProductionComponent> ProductionComponents { get; }
         IDictionary<CategoryFlags, double> ProductionDurations { get; }
-        IDictionary<CategoryFlags, ProductionCost> ProductionCostByCategory { get; }
-        IDictionary<int, ProductionCost> ProductionCostByTechLevel { get; }
+        IDictionary<int, ProductionCost> ProductionCost { get; }
         IDictionary<int, CalibrationDefault> CalibrationDefaults { get; }
 
         ProductionDecalibration GetDecalibration(int targetDefinition);

--- a/src/Perpetuum/Services/ProductionEngine/ProductionCost.cs
+++ b/src/Perpetuum/Services/ProductionEngine/ProductionCost.cs
@@ -46,6 +46,13 @@ namespace Perpetuum.Services.ProductionEngine
             });
         }
 
+        /// <summary>
+        /// Map an EntityDefault to a ProductionCost based on matching CategoryFlags, tierType, tierLevel.
+        /// Tiebreaker logic is weighted such that a match on Category > TierLevel > TierType
+        /// And where a match on TierLevel and Type will not outweigh Category
+        /// </summary>
+        /// <param name="ed">EntityDefault</param>
+        /// <returns>ProductionCost</returns>
         public ProductionCost GetProductionCostByED(EntityDefault ed)
         {
             var matchScores = ProductionCost.GroupBy(c =>

--- a/src/Perpetuum/Services/ProductionEngine/ProductionCost.cs
+++ b/src/Perpetuum/Services/ProductionEngine/ProductionCost.cs
@@ -1,4 +1,9 @@
-﻿
+﻿using System.Collections.Generic;
+using System.Linq;
+using Perpetuum.Data;
+using Perpetuum.EntityFramework;
+using Perpetuum.ExportedTypes;
+
 namespace Perpetuum.Services.ProductionEngine
 {
     public class ProductionCost
@@ -7,5 +12,55 @@ namespace Perpetuum.Services.ProductionEngine
         public int? tierType;
         public int? tierLevel;
         public double costModifier;
+    }
+
+    public interface IProductionCostReader
+    {
+        IEnumerable<ProductionCost> ProductionCost { get; }
+        ProductionCost GetProductionCostByED(EntityDefault ed);
+        double GetProductionCostModByED(EntityDefault ed);
+    }
+
+    public class ProductionCostReader : IProductionCostReader
+    {
+        private const double MIN = 1.0;
+        private const double MAX = 10.0;
+
+        public IEnumerable<ProductionCost> ProductionCost
+        {
+            get { return _costTable.Values; }
+        }
+        private readonly IDictionary<int, ProductionCost> _costTable;
+        public ProductionCostReader()
+        {
+            _costTable = Database.CreateCache<int, ProductionCost>("productioncost", "id", r =>
+            {
+                var cost = new ProductionCost
+                {
+                    categoryFlag = r.GetValue<long?>(k.category),
+                    tierType = r.GetValue<int?>(k.tierType),
+                    tierLevel = r.GetValue<int?>(k.tierLevel),
+                    costModifier = r.GetValue<double>("costmodifier")
+                };
+                return cost;
+            });
+        }
+
+        public ProductionCost GetProductionCostByED(EntityDefault ed)
+        {
+            var matchScores = ProductionCost.GroupBy(c =>
+                (((CategoryFlags)(c.categoryFlag ?? 0) == ed.CategoryFlags) ? 5 : 0) +
+                (((TierType)(c.tierType ?? 0) == ed.Tier.type) ? 1 : 0) +
+                (((c.tierLevel ?? 0) == ed.Tier.level) ? 3 : 0));
+
+            var bestMatchScore = matchScores.Max(x => x.Key);
+            return matchScores.FirstOrDefault(x => x.Key == bestMatchScore).Select(g => g).FirstOrDefault();
+        }
+
+        public double GetProductionCostModByED(EntityDefault ed)
+        {
+            var prodCost = GetProductionCostByED(ed) ?? (new ProductionCost { costModifier = MIN });
+            return prodCost.costModifier.Clamp(MIN, MAX);
+        }
     }
 }

--- a/src/Perpetuum/Services/ProductionEngine/ProductionDataAccess.cs
+++ b/src/Perpetuum/Services/ProductionEngine/ProductionDataAccess.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using Perpetuum.Collections;
 using Perpetuum.Data;
 using Perpetuum.EntityFramework;
 using Perpetuum.ExportedTypes;

--- a/src/Perpetuum/Services/ProductionEngine/ProductionDataAccess.cs
+++ b/src/Perpetuum/Services/ProductionEngine/ProductionDataAccess.cs
@@ -16,8 +16,6 @@ namespace Perpetuum.Services.ProductionEngine
         private IDictionary<int, ItemResearchLevel> _researchlevels;
         private ILookup<int, ProductionComponent> _productionComponents;
         private IDictionary<CategoryFlags, double> _productionDurations;
-        private IDictionary<CategoryFlags, ProductionCost> _productionCostByCategory;
-        private IDictionary<int, ProductionCost> _productionCostByTechLevel;
         private IDictionary<int, CalibrationDefault> _calibrationDefaults;
         private IDictionary<CategoryFlags, ProductionDecalibration> _productionDecalibrations;
 
@@ -68,7 +66,7 @@ namespace Perpetuum.Services.ProductionEngine
                 return level;
             }, ItemResearchLevelFilter);
 
-            _productionCostByCategory = Database.CreateCache<CategoryFlags, ProductionCost>("productioncost", k.category, r =>
+            ProductionCost = Database.CreateCache<int, ProductionCost>("productioncost", "id", r =>
             {
                 var cost = new ProductionCost
                 {
@@ -78,36 +76,7 @@ namespace Perpetuum.Services.ProductionEngine
                     costModifier = r.GetValue<double>("costmodifier")
                 };
                 return cost;
-            }, ProductionCostCategoryFilter);
-
-            _productionCostByTechLevel = Database.CreateCache<int, ProductionCost>("productioncost", k.tierLevel, r =>
-            {
-                var cost = new ProductionCost
-                {
-                    categoryFlag = r.GetValue<long?>(k.category),
-                    tierType = r.GetValue<int?>(k.tierType),
-                    tierLevel = r.GetValue<int?>(k.tierLevel),
-                    costModifier = r.GetValue<double>("costmodifier")
-                };
-                return cost;
-            }, ProductionCostTechFilter);
-        }
-
-        public bool ProductionCostCategoryFilter(IDataRecord record)
-        {
-            long? categoryFlag = record.GetValue<long?>(k.category);
-            if (categoryFlag == null)
-                return false;
-            CategoryFlags flag = (CategoryFlags)categoryFlag;
-            return flag.IsCategoryExists();
-        }
-
-        public bool ProductionCostTechFilter(IDataRecord record)
-        {
-            int? level = record.GetValue<int?>(k.tierLevel);
-            if (level == null)
-                return false;
-            return level > 0;
+            });
         }
 
         public bool ItemResearchLevelFilter(IDataRecord record)
@@ -135,9 +104,8 @@ namespace Perpetuum.Services.ProductionEngine
         public IDictionary<int, ItemResearchLevel> ResearchLevels => _researchlevels;
         public ILookup<int, ProductionComponent> ProductionComponents => _productionComponents;
         public IDictionary<CategoryFlags, double> ProductionDurations => _productionDurations;
-        public IDictionary<CategoryFlags, ProductionCost> ProductionCostByCategory => _productionCostByCategory;
-        public IDictionary<int, ProductionCost> ProductionCostByTechLevel => _productionCostByTechLevel;
         public IDictionary<int, CalibrationDefault> CalibrationDefaults => _calibrationDefaults;
+        public IDictionary<int, ProductionCost> ProductionCost { get; private set; }
 
         public ProductionDecalibration GetDecalibration(int targetDefinition)
         {

--- a/src/Perpetuum/Services/ProductionEngine/ProductionDataAccessExtensions.cs
+++ b/src/Perpetuum/Services/ProductionEngine/ProductionDataAccessExtensions.cs
@@ -80,24 +80,16 @@ namespace Perpetuum.Services.ProductionEngine
         /// <returns>factor to multiply cost</returns>
         public static double GetProductionPriceModifier(this IProductionDataAccess dataAccess, int targetDefinition)
         {
+            var modifier = 1.0;
             if (!EntityDefault.TryGet(targetDefinition, out EntityDefault ed))
             {
                 Logger.Error("definition was not found: " + targetDefinition);
-                return 1.0;
+                return modifier;
             }
 
-            var modifier = 1.0;
-
-            var matchScores = dataAccess.ProductionCost.Values.GroupBy(c =>
-                (((CategoryFlags)(c.categoryFlag ?? 0) == ed.CategoryFlags) ? 5 : 0) +
-                (((TierType)(c.tierType ?? 0) == ed.Tier.type) ? 1 : 0) +
-                (((c.tierLevel ?? 0) == ed.Tier.level) ? 3 : 0));
-
-            var bestMatchScore = matchScores.Max(x => x.Key);
-            var resultCost = matchScores.FirstOrDefault(x => x.Key == bestMatchScore).Select(g => g).FirstOrDefault();
-            if (resultCost != null)
+            if (dataAccess.ProductionCost.TryGetValue(ed.Definition, out double value))
             {
-                modifier = resultCost.costModifier;
+                modifier = value;
             }
             return modifier;
         }

--- a/src/Perpetuum/Services/ProductionEngine/ProductionDataAccessExtensions.cs
+++ b/src/Perpetuum/Services/ProductionEngine/ProductionDataAccessExtensions.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Perpetuum.EntityFramework;
-using Perpetuum.ExportedTypes;
 using Perpetuum.Log;
 using Perpetuum.Services.ProductionEngine.CalibrationPrograms;
 


### PR DESCRIPTION
Previously we only needed to map cost by just a category or just a tech level - that was the MVP at the time.
Now we have our first case of wanting different cost based on tierLevel and tierType.
Soon gamma too will want to mix category and level as well.

Thus this refactor removes caching lookup dictionaries by just one particular key, and instead pulls the table into one collection to be filtered on dynamically.

Each EntityDefault will match against ProductionCost entries by category, tierType, and tierlevel, and pick the one that matches the most of these filters - scoring them based on number matched.
Because there can be ties (category and level, level and type) a weight is set for each match to weigh the most important thing to filter by, then the differentiators.  Category>Level>Type.

For example if a level 2, category A, type 3 item will only match the production cost in the following order, picking the first one that matches:

1. Category A, level 2, type 3
2. Category A, level 2
3. Category A
4. Level 2, type 3
5. Level 2,
6. Type 3

If there is no match it defaults to 1.0 as usual.