### PR TITLE
Issue 257: Server "Admins only" mode

### DIFF
--- a/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandHandlers.cs
+++ b/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandHandlers.cs
@@ -150,8 +150,7 @@ namespace Perpetuum.Services.Channels.ChatCommands
         {
             string cmd = string.Format("relayClose:relay:null");
             HandleLocalRequest(data, cmd);
-            data.Channel.SendMessageToAll(data.SessionManager, data.Sender, string.Format("Relay Closed >> Only Admins can Login"));
-
+            data.Channel.SendMessageToAll(data.SessionManager, data.Sender, string.Format("Relay is Closed >> Only Admins can Login"));
         }
 
         [ChatCommand("RelayOpen")]
@@ -159,8 +158,7 @@ namespace Perpetuum.Services.Channels.ChatCommands
         {
             string cmd = string.Format("relayOpen:relay:null");
             HandleLocalRequest(data, cmd);
-            data.Channel.SendMessageToAll(data.SessionManager, data.Sender, string.Format("Relay Open >> All Players can Login"));
-
+            data.Channel.SendMessageToAll(data.SessionManager, data.Sender, string.Format("Relay is Open >> All Players can Login"));
         }
 
         [ChatCommand("ShutdownCancel")]

--- a/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandHandlers.cs
+++ b/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandHandlers.cs
@@ -144,6 +144,25 @@ namespace Perpetuum.Services.Channels.ChatCommands
             string cmd = string.Format("serverShutDown:relay:{0}", GenxyConverter.Serialize(dictionary));
             HandleLocalRequest(data, cmd);
         }
+
+        [ChatCommand("RelayClose")]
+        public static void RelayClosed(AdminCommandData data)
+        {
+            string cmd = string.Format("relayClose:relay:null");
+            HandleLocalRequest(data, cmd);
+            data.Channel.SendMessageToAll(data.SessionManager, data.Sender, string.Format("Relay Closed >> Only Admins can Login"));
+
+        }
+
+        [ChatCommand("RelayOpen")]
+        public static void RelayOpen(AdminCommandData data)
+        {
+            string cmd = string.Format("relayOpen:relay:null");
+            HandleLocalRequest(data, cmd);
+            data.Channel.SendMessageToAll(data.SessionManager, data.Sender, string.Format("Relay Open >> All Players can Login"));
+
+        }
+
         [ChatCommand("ShutdownCancel")]
         public static void ShutdownCancel(AdminCommandData data)
         {


### PR DESCRIPTION
### Summary
This is a step on the path to solve #257 
This change hooks up two new admin commands for the in-game chat => `#relayclose` and `#relayopen`
They require accessLevel of admin
https://github.com/OpenPerpetuum/PerpetuumServer/blob/bd606e24b869e1b91673c39c8ddbf7d34cf07006/src/Perpetuum/Commands.cs#L1054-L1064

By default the server is starting in "relayopen" mode, meaning it is open to the public and anyone can join. (This is unchanged behaviour)



Once an admin has `#secure`d a channel and then ran the `#relayclose` command, normal players are no longer able to login to the server. 

This is thanks to the flow of our Sign In handler
https://github.com/OpenPerpetuum/PerpetuumServer/blob/bd606e24b869e1b91673c39c8ddbf7d34cf07006/src/Perpetuum.RequestHandlers/SignInRequestHandler.cs#L31-L34

RelayClose, only closes it to the public (and not entirely for everyone) by setting the RelayState as such:

https://github.com/OpenPerpetuum/PerpetuumServer/blob/bd606e24b869e1b91673c39c8ddbf7d34cf07006/src/Perpetuum.RequestHandlers/RelayClose.cs#L17


### Caveats
Closing the relay has zero effect on normal players who already passed the login screen -> Meaning if they are sitting on Character Select or is in game, they can continue playing.

This will only block new attempts to log on to the server.

### How to test
Requires 2 game accounts
One that is a regular account, and one that is of accessLevel Admin (tool or game, either works)

Apply the changes from this PR, then run the server.

- Login with your regular account, as a sanity check. Logout again.
- Login with your Admin Account, and enter the game with a character.
- `#secure` a chat channel, and then run the  `#relayclose` command.
- - The server should no longer accept logins from normal accounts
- Logout of Admin Account
-  Attempt to login with a normal account.
- You should see "error_RelayIsClosedForPublic"
- Log back in on your Admin Account, and in a `#secure` chat channel run the `#relayopen` command.
- Logout of Admin Account
- Attempt a login from the normal account, you should successfully get in now.