### PR TITLE
Issue 257: Support for OnlyAllowAdmins as a server startup config

### DIFF
--- a/src/Perpetuum.AdminTool/LocalServerRunner.cs
+++ b/src/Perpetuum.AdminTool/LocalServerRunner.cs
@@ -356,7 +356,6 @@ namespace Perpetuum.AdminTool
             if (!File.Exists(perpetuumIni))
             {
                 _log.StatusError($"{PERPETUUMINIFILE} was not found in game root {gameRoot} folder. Check your settings!");
-                return null;
             }
 
             var json = File.ReadAllText(perpetuumIni);

--- a/src/Perpetuum.AdminTool/LocalServerRunner.cs
+++ b/src/Perpetuum.AdminTool/LocalServerRunner.cs
@@ -100,6 +100,16 @@ namespace Perpetuum.AdminTool
                     return;
                 }
 
+                var adminOnlyMode = GetAdminOnlyModeFromIni(gameRoot);
+                if (!adminOnlyMode)
+                {
+                    _log.Log("AdminOnlyMode: Disabled (Default)");
+                }
+                else
+                {
+                    _log.Log("AdminOnlyMode: Enabled");
+                }
+
                 //RunNetStatProbe(listeningPort);
                 RunSocketProbe(listeningPort);
             }
@@ -353,6 +363,26 @@ namespace Perpetuum.AdminTool
             _log.Log($"Relay port loaded from {PERPETUUMINIFILE}: {portData.ListenerPort}");
 
             return portData.ListenerPort;
+        }
+
+        private bool GetAdminOnlyModeFromIni(string gameRoot)
+        {
+            var perpetuumIni = Path.Combine(gameRoot, PERPETUUMINIFILE);
+            if (!File.Exists(perpetuumIni))
+            {
+                _log.StatusError($"{PERPETUUMINIFILE} was not found in game root {gameRoot} folder. Check your settings!");
+                return false;
+            }
+
+            var json = File.ReadAllText(perpetuumIni);
+            var adminOnlyMode = JsonConvert.DeserializeAnonymousType(json, new
+            {
+                StartServerInAdminOnlyMode = false,
+            });
+
+            _log.Log($"Startup in Admin Only Mode loaded from {PERPETUUMINIFILE}: {adminOnlyMode.StartServerInAdminOnlyMode}");
+
+            return adminOnlyMode.StartServerInAdminOnlyMode;
         }
 
 

--- a/src/Perpetuum.RequestHandlers/RelayClose.cs
+++ b/src/Perpetuum.RequestHandlers/RelayClose.cs
@@ -14,7 +14,9 @@ namespace Perpetuum.RequestHandlers
 
         public void HandleRequest(IRequest request)
         {
+            _relayStateService.ConfigOnlyAllowAdmins(true);
             _relayStateService.State = RelayState.OpenForAdminsOnly;
+            
             Message.Builder.FromRequest(request).WithOk().Send();
         }
     }

--- a/src/Perpetuum.RequestHandlers/RelayOpen.cs
+++ b/src/Perpetuum.RequestHandlers/RelayOpen.cs
@@ -14,7 +14,9 @@ namespace Perpetuum.RequestHandlers
 
         public void HandleRequest(IRequest request)
         {
+            _relayStateService.ConfigOnlyAllowAdmins(false);
             _relayStateService.State = RelayState.OpenForPublic;
+
             Message.Builder.FromRequest(request).WithOk().Send();
         }
     }

--- a/src/Perpetuum/GlobalConfiguration.cs
+++ b/src/Perpetuum/GlobalConfiguration.cs
@@ -21,5 +21,7 @@ namespace Perpetuum
         public bool EnableDev { get; set; }
 
         public CorporationConfiguration Corporation { get; set; }
+
+        public bool StartServerInAdminOnlyMode { get; set; }
     }
 }

--- a/src/Perpetuum/Services/Relay/IRelayStateService.cs
+++ b/src/Perpetuum/Services/Relay/IRelayStateService.cs
@@ -8,5 +8,6 @@ namespace Perpetuum.Services.Relay
         RelayState State { get; set; }
         event Action<RelayState> StateChanged;
         void SendStateToClient(ISession session);
+        void ConfigOnlyAllowAdmins(bool enabled);
     }
 }

--- a/src/Perpetuum/Services/Relay/RelayInfoBuilder.cs
+++ b/src/Perpetuum/Services/Relay/RelayInfoBuilder.cs
@@ -41,6 +41,11 @@ namespace Perpetuum.Services.Relay
 
         public RelayInfo Build()
         {
+            if (_globalConfiguration.StartServerInAdminOnlyMode)
+            {
+                _relayStateService.State = RelayState.OpenForAdminsOnly;
+            }
+
             var info = new RelayInfo
             {
                 state = _relayStateService.State,
@@ -48,7 +53,13 @@ namespace Perpetuum.Services.Relay
                 usersCount = _sessionManager.Sessions.Count(),
                 maxUsers = _sessionManager.MaxSessions
             };
+
             return info;
+        }
+
+        public void ConfigOnlyAllowAdmins(bool enabled)
+        {
+            _globalConfiguration.StartServerInAdminOnlyMode = enabled;
         }
     }
 }

--- a/src/Perpetuum/Services/Relay/RelayStateService.cs
+++ b/src/Perpetuum/Services/Relay/RelayStateService.cs
@@ -51,5 +51,11 @@ namespace Perpetuum.Services.Relay
             var info = builder.Build();
             return Message.Builder.SetCommand(Commands.State).WithData(info.ToDictionary());
         }
+
+        public void ConfigOnlyAllowAdmins(bool enabled)
+        {
+            var factory = _relayInfoBuilderFactory();
+            factory.ConfigOnlyAllowAdmins(enabled);
+        }
     }
 }


### PR DESCRIPTION
This change introduces `  "StartServerInAdminOnlyMode": true/false` as a key in the `data/perpetuum.ini` file.

If it's set to true, the server will start up with the `RelayState.OpenForAdminsOnly` state.
This state can then be changed during runtime, by logging in on an admin game account and doing `#relayopen` or `#relayclose`. This will not edit the perpetuum.ini file, only the currently running state.

If the `StartServerInAdminOnlymode` key is missing from the .ini file, we default to false - Meaning the server will start up with `RelayState.OpenForPublic`

The already merged PR #290 + this PR = Closes #257 
Test:

- Set `"StartServerInAdminOnlyMode": true` in the .ini file
- Start server
- Login with a regular player account
- - Expect: Error - relay closed to public
- Login with admin player account
- do `#secure` and `#relayopen` in a chat
- Attempt to login with a regular player account
- - Expect: Succesful login

Sanity:
- Set `"StartServerInAdminOnlyMode": false`  (or alternatively, remove the StartServerInAdminOnlyMode key completely)
- Start server
- Login with a regular player account
- - Expect: Succesful login