### PR TITLE
Itemshop return valid definitions

### DIFF
--- a/src/Perpetuum/Services/ItemShop/ItemShop.cs
+++ b/src/Perpetuum/Services/ItemShop/ItemShop.cs
@@ -40,7 +40,9 @@ namespace Perpetuum.Services.ItemShop
         {
             const string qryStr = @"SELECT * FROM dbo.itemshop AS its
                                     JOIN itemshoplocations sl ON its.presetid = sl.presetid
-                                    WHERE sl.locationeid = @eid AND its.id = @id";
+                                    JOIN entitydefaults d on its.targetdefinition = d.definition
+                                    WHERE d.enabled=1 AND d.hidden=0 AND
+                                    sl.locationeid = @eid AND its.id = @id";
 
             var record = Db.Query().CommandText(qryStr).SetParameter("@eid", Eid).SetParameter("@id", entryID).ExecuteSingleRow();
             if (record == null)
@@ -54,7 +56,9 @@ namespace Perpetuum.Services.ItemShop
         {
             const string qryStr = @"SELECT * FROM dbo.itemshop AS its
                                     JOIN itemshoplocations sl ON its.presetid = sl.presetid
-                                    WHERE sl.locationeid = @eid";
+                                    JOIN entitydefaults d on its.targetdefinition = d.definition
+                                    WHERE d.enabled=1 AND d.hidden=0 AND 
+                                    sl.locationeid = @eid";
 
             var records = Db.Query().CommandText(qryStr).SetParameter("@eid", Eid).Execute();
 


### PR DESCRIPTION
As the result of disabling entitydefaults in the DB, when `EntityDefault.Get(id)` is called, it will return def:0 undefined for disabled defaults.
Everything is fine right up until the client receives such a definition and it crashes.
The client doesn't crash in other contexts where a disabled item might be returned, but whether or not this could be handled in the client isn't within the scope of this project.

The fix is to filter out the hidden/disabled ED's when queried.