### PR TITLE
Container depth check

### DIFF
--- a/src/Perpetuum.RequestHandlers/Zone/Containers/ZoneContainerRequestHandler.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/Containers/ZoneContainerRequestHandler.cs
@@ -57,19 +57,23 @@ namespace Perpetuum.RequestHandlers.Zone.Containers
             return ErrorCodes.NoError;
         }
 
+        [CanBeNull]
         private static FieldTerminal GetFieldTerminal(Entity container)
         {
             if (container == null)
                 return null;
 
+            var maxDepth = 9;
+            var depth = 0;
             var fieldTerminal = container.ParentEntity as FieldTerminal;
-            while (fieldTerminal == null)
+            while (fieldTerminal == null && depth < maxDepth)
             {
                 container = container.ParentEntity;
                 if(container == null)
                     break;
 
                 fieldTerminal = container.ParentEntity as FieldTerminal;
+                depth++;
             }
             return fieldTerminal;
         }

--- a/src/Perpetuum.RequestHandlers/Zone/Containers/ZoneContainerRequestHandler.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/Containers/ZoneContainerRequestHandler.cs
@@ -65,15 +65,14 @@ namespace Perpetuum.RequestHandlers.Zone.Containers
 
             var maxDepth = 9;
             var depth = 0;
-            var current = container;
-            var fieldTerminal = current.ParentEntity as FieldTerminal;
+            var fieldTerminal = container.ParentEntity as FieldTerminal;
             while (fieldTerminal == null && depth < maxDepth)
             {
-                current = current.ParentEntity;
-                if(current == null)
+                container = container.ParentEntity;
+                if(container == null)
                     break;
 
-                fieldTerminal = current.ParentEntity as FieldTerminal;
+                fieldTerminal = container.ParentEntity as FieldTerminal;
                 depth++;
             }
             return fieldTerminal;

--- a/src/Perpetuum.RequestHandlers/Zone/Containers/ZoneContainerRequestHandler.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/Containers/ZoneContainerRequestHandler.cs
@@ -65,14 +65,15 @@ namespace Perpetuum.RequestHandlers.Zone.Containers
 
             var maxDepth = 9;
             var depth = 0;
-            var fieldTerminal = container.ParentEntity as FieldTerminal;
+            var current = container;
+            var fieldTerminal = current.ParentEntity as FieldTerminal;
             while (fieldTerminal == null && depth < maxDepth)
             {
-                container = container.ParentEntity;
-                if(container == null)
+                current = current.ParentEntity;
+                if(current == null)
                     break;
 
-                fieldTerminal = container.ParentEntity as FieldTerminal;
+                fieldTerminal = current.ParentEntity as FieldTerminal;
                 depth++;
             }
             return fieldTerminal;


### PR DESCRIPTION
Limit max depth of exploration of parent containers in case of cyclic or recursively parented entities.
It *shouldn't* happen, but that isn't enough to make this not haunt my dreams.