### PR TITLE
Stronghold timelimit and anti-camp mechanics

### DIFF
--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -182,6 +182,7 @@ using SetItemName = Perpetuum.RequestHandlers.SetItemName;
 using TrashItems = Perpetuum.RequestHandlers.TrashItems;
 using UnpackItems = Perpetuum.RequestHandlers.UnpackItems;
 using UnstackAmount = Perpetuum.RequestHandlers.UnstackAmount;
+using Perpetuum.Services.Strongholds;
 
 namespace Perpetuum.Bootstrapper
 {
@@ -2550,6 +2551,22 @@ namespace Perpetuum.Bootstrapper
             _builder.RegisterType<SettingsLoader>();
             _builder.RegisterType<PlantRuleLoader>();
 
+            _builder.RegisterType<StrongholdPlayerStateManager>().OnActivated(e =>
+            {
+                var pm = e.Context.Resolve<IProcessManager>();
+                pm.AddProcess(e.Instance.AsTimed(TimeSpan.FromSeconds(30)).ToAsync());
+            }).As<IStrongholdPlayerStateManager>();
+
+
+            _builder.Register<Func<IZone, IStrongholdPlayerStateManager>>(x =>
+            {
+                var ctx = x.Resolve<IComponentContext>();
+                return zone =>
+                {
+                    return new StrongholdPlayerStateManager(zone, ctx.Resolve<ISessionManager>());
+                };
+            });
+
             _builder.Register<Func<ZoneConfiguration, IZone>>(x =>
             {
                 var ctx = x.Resolve<IComponentContext>();
@@ -2581,6 +2598,11 @@ namespace Perpetuum.Bootstrapper
                     {
                         zone.HighwayHandler = ctx.Resolve<PBSHighwayHandler.Factory>().Invoke(zone);
                         zone.TerraformHandler = ctx.Resolve<TerraformHandler.Factory>().Invoke(zone);
+                    }
+
+                    if (configuration.Type == ZoneType.Stronghold)
+                    {
+                        zone.PlayerStateManager = ctx.Resolve<Func<IZone, IStrongholdPlayerStateManager>>().Invoke(zone);
                     }
 
                     ctx.Resolve<EventListenerService>().AttachListener(new NpcReinforcementSpawner(zone, ctx.Resolve<INpcReinforcementsRepository>()));

--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -2563,7 +2563,7 @@ namespace Perpetuum.Bootstrapper
                 var ctx = x.Resolve<IComponentContext>();
                 return zone =>
                 {
-                    return new StrongholdPlayerStateManager(zone, ctx.Resolve<ISessionManager>());
+                    return new StrongholdPlayerStateManager(zone);
                 };
             });
 

--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -2551,11 +2551,7 @@ namespace Perpetuum.Bootstrapper
             _builder.RegisterType<SettingsLoader>();
             _builder.RegisterType<PlantRuleLoader>();
 
-            _builder.RegisterType<StrongholdPlayerStateManager>().OnActivated(e =>
-            {
-                var pm = e.Context.Resolve<IProcessManager>();
-                pm.AddProcess(e.Instance.AsTimed(TimeSpan.FromSeconds(30)).ToAsync());
-            }).As<IStrongholdPlayerStateManager>();
+            _builder.RegisterType<StrongholdPlayerStateManager>().As<IStrongholdPlayerStateManager>();
 
 
             _builder.Register<Func<IZone, IStrongholdPlayerStateManager>>(x =>

--- a/src/Perpetuum.ExportedTypes/EffectType.cs
+++ b/src/Perpetuum.ExportedTypes/EffectType.cs
@@ -114,6 +114,7 @@ namespace Perpetuum.ExportedTypes
         effect_night_clear = 111,
         effect_night_overcast = 112,
         effect_weather_good = 113,
-        effect_weather_bad = 114
+        effect_weather_bad = 114,
+        effect_stronghold_despawn_timer = 115
     }
 }

--- a/src/Perpetuum/Keywords.cs
+++ b/src/Perpetuum/Keywords.cs
@@ -1007,6 +1007,7 @@ namespace Perpetuum
         public const string state = "state";
         public const string steambuildid = "steamBuildId";
         public const string steps = "steps";
+        public const string strongholdDespawnTime = "strongholdDespawnTime";
         public const string structureEid = "structureEid";
         public const string sub = "sub";
         public const string submitInterval = "submitInterval";

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -561,6 +561,7 @@
     <Compile Include="Services\Sparks\Teleports\SparkTeleportHelper.cs" />
     <Compile Include="Services\Sparks\Teleports\SparkTeleportRepository.cs" />
     <Compile Include="Services\Steam\SteamHelper.cs" />
+    <Compile Include="Services\Strongholds\StrongholdPlayerStateManager.cs" />
     <Compile Include="Services\Weather\IWeatherService.cs" />
     <Compile Include="Services\Weather\WeatherInfo.cs" />
     <Compile Include="Services\Weather\WeatherObservers.cs" />

--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -253,7 +253,9 @@ namespace Perpetuum.Players
             MissionHandler = _missionHandlerFactory(zone, this);
             MissionHandler.InitMissions();
 
-            Direction = FastRandom.NextDouble(); 
+            Direction = FastRandom.NextDouble();
+
+            zone.PlayerStateManager?.OnPlayerEnterZone(this);
 
             var p = DynamicProperties.GetProperty<int>(k.pvpRemaining);
             if (!p.HasValue)
@@ -269,6 +271,8 @@ namespace Perpetuum.Players
             zone.SendPacketToGang(Gang, new GangUpdatePacketBuilder(Visibility.Invisible, this));
 
             _check.StopAndDispose();
+
+            zone.PlayerStateManager?.OnPlayerExitZone(this);
 
             if (!States.LocalTeleport)
                 Session.Stop();
@@ -330,8 +334,14 @@ namespace Perpetuum.Players
             //if (StrongholdPlayerDespawnHelper.HasEffect(this))
             //    return;
 
-            _despawnHelper = StrongholdPlayerDespawnHelper.Create(this, time);
-            _despawnHelper.DespawnStrategy = strategy;
+            Task.Delay(5000).ContinueWith(t =>
+            {
+                if (_despawnHelper == null)
+                {
+                    _despawnHelper = StrongholdPlayerDespawnHelper.Create(this, time);
+                    _despawnHelper.DespawnStrategy = strategy;
+                }
+            });
         }
 
         public void ClearStrongholdDespawn()

--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -137,6 +137,7 @@ namespace Perpetuum.Players
         private readonly PlayerMovement _movement;
         private CombatLogger _combatLogger;
         private PlayerMoveCheckQueue _check;
+        private UnitDespawnHelper _despawnHelper;
 
         public Player(IExtensionReader extensionReader,
             ICorporationManager corporationManager,
@@ -320,6 +321,16 @@ namespace Perpetuum.Players
             MissionHandler.Update(time);
 
             _combatLogger?.Update(time);
+            _despawnHelper?.Update(time, this);
+        }
+
+        public void SetDespawn(TimeSpan time, UnitDespawnStrategy strategy)
+        {
+            if (HasDespawnEffect)
+                return;
+
+            _despawnHelper = UnitDespawnHelper.Create(this, time);
+            _despawnHelper.DespawnStrategy = strategy;
         }
 
         public void SendModuleProcessError(Module module, ErrorCodes error)
@@ -345,7 +356,6 @@ namespace Perpetuum.Players
         {
             EffectHandler.RemoveEffectsByType(EffectType.effect_invulnerable);
         }
-
 
         public void ApplyTeleportSicknessEffect()
         {

--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -255,8 +255,6 @@ namespace Perpetuum.Players
 
             Direction = FastRandom.NextDouble();
 
-            zone.PlayerStateManager?.OnPlayerEnterZone(this);
-
             var p = DynamicProperties.GetProperty<int>(k.pvpRemaining);
             if (!p.HasValue)
                 return;
@@ -271,8 +269,6 @@ namespace Perpetuum.Players
             zone.SendPacketToGang(Gang, new GangUpdatePacketBuilder(Visibility.Invisible, this));
 
             _check.StopAndDispose();
-
-            zone.PlayerStateManager?.OnPlayerExitZone(this);
 
             if (!States.LocalTeleport)
                 Session.Stop();
@@ -331,17 +327,11 @@ namespace Perpetuum.Players
 
         public void SetStrongholdDespawn(TimeSpan time, UnitDespawnStrategy strategy)
         {
-            //if (StrongholdPlayerDespawnHelper.HasEffect(this))
-            //    return;
-
-            Task.Delay(5000).ContinueWith(t =>
+            if (_despawnHelper == null)
             {
-                if (_despawnHelper == null)
-                {
-                    _despawnHelper = StrongholdPlayerDespawnHelper.Create(this, time);
-                    _despawnHelper.DespawnStrategy = strategy;
-                }
-            });
+                _despawnHelper = StrongholdPlayerDespawnHelper.Create(this, time);
+                _despawnHelper.DespawnStrategy = strategy;
+            }
         }
 
         public void ClearStrongholdDespawn()

--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -25,6 +25,7 @@ using Perpetuum.Services.Looting;
 using Perpetuum.Services.MissionEngine;
 using Perpetuum.Services.MissionEngine.MissionTargets;
 using Perpetuum.Services.MissionEngine.TransportAssignments;
+using Perpetuum.Services.Strongholds;
 using Perpetuum.Timers;
 using Perpetuum.Units;
 using Perpetuum.Units.DockingBases;
@@ -137,7 +138,7 @@ namespace Perpetuum.Players
         private readonly PlayerMovement _movement;
         private CombatLogger _combatLogger;
         private PlayerMoveCheckQueue _check;
-        private UnitDespawnHelper _despawnHelper;
+        private StrongholdPlayerDespawnHelper _despawnHelper;
 
         public Player(IExtensionReader extensionReader,
             ICorporationManager corporationManager,
@@ -324,13 +325,19 @@ namespace Perpetuum.Players
             _despawnHelper?.Update(time, this);
         }
 
-        public void SetDespawn(TimeSpan time, UnitDespawnStrategy strategy)
+        public void SetStrongholdDespawn(TimeSpan time, UnitDespawnStrategy strategy)
         {
-            if (HasDespawnEffect)
-                return;
+            //if (StrongholdPlayerDespawnHelper.HasEffect(this))
+            //    return;
 
-            _despawnHelper = UnitDespawnHelper.Create(this, time);
+            _despawnHelper = StrongholdPlayerDespawnHelper.Create(this, time);
             _despawnHelper.DespawnStrategy = strategy;
+        }
+
+        public void ClearStrongholdDespawn()
+        {
+            _despawnHelper?.Cancel(this);
+            _despawnHelper = null;
         }
 
         public void SendModuleProcessError(Module module, ErrorCodes error)

--- a/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
+++ b/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
@@ -1,0 +1,83 @@
+﻿using Perpetuum.Accounting.Characters;
+using Perpetuum.Data;
+using Perpetuum.Services.Sessions;
+using Perpetuum.Threading.Process;
+using Perpetuum.Timers;
+using Perpetuum.Zones;
+using System;
+using System.Linq;
+
+namespace Perpetuum.Services.Strongholds
+{
+    public interface IStrongholdPlayerStateManager : IProcess { }
+
+    public class StrongholdPlayerStateManager : Process, IStrongholdPlayerStateManager
+    {
+        private readonly IZone _zone;
+        private readonly ISessionManager _sessionManager;
+        private readonly TimeTracker _updateTimer = new TimeTracker(TimeSpan.FromSeconds(31));
+        public StrongholdPlayerStateManager(IZone zone, ISessionManager sessionManager)
+        {
+            _zone = zone;
+            _sessionManager = sessionManager;
+        }
+
+        public override void Update(TimeSpan time)
+        {
+            _updateTimer.Update(time);
+            if (_updateTimer.Expired)
+            {
+                DoCheck();
+                _updateTimer.Reset();
+            }
+        }
+
+        public void DoCheck()
+        {
+            DockUpOfflinePlayers();
+            var characters = _zone.Players.Where(p => p.Session.InactiveTime > TimeSpan.FromMinutes(3)).Select(p => p.Character);
+            foreach (var character in characters)
+            {
+                DockPlayer(character);
+            }
+        }
+
+        private void DockUpOfflinePlayers()
+        {
+            using (var scope = Db.CreateTransaction())
+            {
+                // Query for all offline chars on zone
+                var offlineCharIds = Db.Query().CommandText(
+                    $"SELECT characterID FROM characters WHERE inUse=0 AND zoneID=@zoneId;")
+                    .SetParameter("@zoneId", _zone.Id)
+                    .Execute()
+                    .Select(r => r.GetValue<int>("characterID"));
+
+                // Set DB state of characters to be docked at homebase
+                foreach (var charId in offlineCharIds)
+                {
+                    Db.Query().CommandText("opp.characterForceDockHome")
+                                        .SetParameter("@characterId", charId)
+                                        .ExecuteNonQuery();
+                }
+                scope.Complete();
+            }
+        }
+
+        private void DockPlayer(Character character)
+        {
+            using (var scope = Db.CreateTransaction())
+            {
+                // Dock player to homebase
+                var dockingBase = character.GetHomeBaseOrCurrentBase();
+                dockingBase.DockIn(character, TimeSpan.FromSeconds(5), ZoneExitType.Docked);
+
+                // Send update to client if online
+                var session = _sessionManager.GetByCharacter(character);
+                Message.Builder.ToClient(session).WithError(ErrorCodes.YouAreHappyNow).Send();
+
+                scope.Complete();
+            }
+        }
+    }
+}

--- a/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
+++ b/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
@@ -66,7 +66,7 @@ namespace Perpetuum.Services.Strongholds
 
     public class StrongholdPlayerDespawnHelper : UnitDespawnHelper
     {
-        private static readonly EffectType DespawnEffect = EffectType.effect_despawn_timer; //TODO new custom type
+        private static readonly EffectType DespawnEffect = EffectType.effect_stronghold_despawn_timer;
 
         private StrongholdPlayerDespawnHelper(TimeSpan despawnTime) : base(despawnTime) { }
 

--- a/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
+++ b/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
@@ -5,7 +5,9 @@ using Perpetuum.Threading.Process;
 using Perpetuum.Timers;
 using Perpetuum.Zones;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Transactions;
 
 namespace Perpetuum.Services.Strongholds
 {
@@ -13,9 +15,14 @@ namespace Perpetuum.Services.Strongholds
 
     public class StrongholdPlayerStateManager : Process, IStrongholdPlayerStateManager
     {
+        private readonly TimeSpan MAX_IDLE_TIME = TimeSpan.FromMinutes(1.5); //TODO: test value, TBD time period of no client activity
+        private readonly TimeSpan MAX_DISCONNECT_TIME = TimeSpan.FromMinutes(2); //TODO: test value, TBD time period of logged off character
         private readonly IZone _zone;
         private readonly ISessionManager _sessionManager;
         private readonly TimeTracker _updateTimer = new TimeTracker(TimeSpan.FromSeconds(31));
+
+        private IDictionary<int, TimeTracker> _loggedOffCharacters = new Dictionary<int, TimeTracker>();
+
         public StrongholdPlayerStateManager(IZone zone, ISessionManager sessionManager)
         {
             _zone = zone;
@@ -27,40 +34,66 @@ namespace Perpetuum.Services.Strongholds
             _updateTimer.Update(time);
             if (_updateTimer.Expired)
             {
-                DoCheck();
+                DoCheck(time);
                 _updateTimer.Reset();
             }
         }
 
-        public void DoCheck()
+        public void DoCheck(TimeSpan time)
         {
-            DockUpOfflinePlayers();
-            var characters = _zone.Players.Where(p => p.Session.InactiveTime > TimeSpan.FromMinutes(3)).Select(p => p.Character);
-            foreach (var character in characters)
-            {
-                DockPlayer(character);
-            }
+            DockUpOfflinePlayers(time);
+            DockOnlinePlayers();
         }
 
-        private void DockUpOfflinePlayers()
+        private void DockUpOfflinePlayers(TimeSpan time)
         {
+            IEnumerable<int> offlineCharIds;
             using (var scope = Db.CreateTransaction())
             {
                 // Query for all offline chars on zone
-                var offlineCharIds = Db.Query().CommandText(
+                offlineCharIds = Db.Query().CommandText(
                     $"SELECT characterID FROM characters WHERE inUse=0 AND zoneID=@zoneId;")
                     .SetParameter("@zoneId", _zone.Id)
                     .Execute()
                     .Select(r => r.GetValue<int>("characterID"));
 
-                // Set DB state of characters to be docked at homebase
                 foreach (var charId in offlineCharIds)
                 {
-                    Db.Query().CommandText("opp.characterForceDockHome")
-                                        .SetParameter("@characterId", charId)
-                                        .ExecuteNonQuery();
+                    // Track how long character is logged off for
+                    if (_loggedOffCharacters.ContainsKey(charId))
+                    {
+                        _loggedOffCharacters[charId].Update(time);
+                    }
+                    else
+                    {
+                        _loggedOffCharacters[charId] = new TimeTracker(MAX_DISCONNECT_TIME);
+                    }
+
+                    // Set DB state of characters to be docked at homebase
+                    if (_loggedOffCharacters[charId].Expired)
+                    {
+                        Db.Query().CommandText("opp.characterForceDockHome")
+                            .SetParameter("@characterId", charId)
+                            .ExecuteNonQuery();
+                        // Remove character id from tracking
+                        _loggedOffCharacters.Remove(charId);
+                    }
                 }
                 scope.Complete();
+            }
+            // Remove any ids from tracking that are no longer in the current logged off set
+            foreach (var key in _loggedOffCharacters.Keys.Where(k => !offlineCharIds.Contains(k)))
+            {
+                _loggedOffCharacters.Remove(key);
+            }
+        }
+
+        private void DockOnlinePlayers()
+        {
+            var characters = _zone.Players.Where(p => p.Session.InactiveTime > MAX_IDLE_TIME).Select(p => p.Character);
+            foreach (var character in characters)
+            {
+                DockPlayer(character);
             }
         }
 
@@ -72,9 +105,12 @@ namespace Perpetuum.Services.Strongholds
                 var dockingBase = character.GetHomeBaseOrCurrentBase();
                 dockingBase.DockIn(character, TimeSpan.FromSeconds(5), ZoneExitType.Docked);
 
-                // Send update to client if online
-                var session = _sessionManager.GetByCharacter(character);
-                Message.Builder.ToClient(session).WithError(ErrorCodes.YouAreHappyNow).Send();
+                Transaction.Current.OnCommited(() =>
+                {
+                    // Send update to client if online
+                    var session = _sessionManager.GetByCharacter(character);
+                    Message.Builder.ToClient(session).WithError(ErrorCodes.YouAreHappyNow).Send();
+                });
 
                 scope.Complete();
             }

--- a/src/Perpetuum/Units/UnitDespawnHelper.cs
+++ b/src/Perpetuum/Units/UnitDespawnHelper.cs
@@ -10,19 +10,19 @@ namespace Perpetuum.Units
 
     public class UnitDespawnHelper 
     {
-        private readonly TimeSpan _despawnTime;
-        private readonly IntervalTimer _timer = new IntervalTimer(500);
+        protected readonly TimeSpan _despawnTime;
+        protected readonly IntervalTimer _timer = new IntervalTimer(500);
 
-        private UnitDespawnHelper(TimeSpan despawnTime)
+        protected UnitDespawnHelper(TimeSpan despawnTime)
         {
             _despawnTime = despawnTime;
         }
 
-        public UnitDespawnerCanApplyEffect CanApplyDespawnEffect { private get; set; }
+        public UnitDespawnerCanApplyEffect CanApplyDespawnEffect { protected get; set; }
 
-        public UnitDespawnStrategy DespawnStrategy { private get; set; }
+        public UnitDespawnStrategy DespawnStrategy { protected get; set; }
 
-        public void Update(TimeSpan time,Unit unit)
+        public virtual void Update(TimeSpan time,Unit unit)
         {
             _timer.Update(time).IsPassed(() =>
             {
@@ -44,7 +44,7 @@ namespace Perpetuum.Units
             });
         }
 
-        private readonly EffectToken _effectToken = EffectToken.NewToken();
+        protected readonly EffectToken _effectToken = EffectToken.NewToken();
 
         private void TryReApplyDespawnEffect(Unit unit)
         {

--- a/src/Perpetuum/Units/UnitDespawnHelper.cs
+++ b/src/Perpetuum/Units/UnitDespawnHelper.cs
@@ -11,7 +11,7 @@ namespace Perpetuum.Units
     public class UnitDespawnHelper 
     {
         protected readonly TimeSpan _despawnTime;
-        protected readonly IntervalTimer _timer = new IntervalTimer(500);
+        protected readonly IntervalTimer _timer = new IntervalTimer(650);
 
         protected UnitDespawnHelper(TimeSpan despawnTime)
         {

--- a/src/Perpetuum/Zones/IZone.cs
+++ b/src/Perpetuum/Zones/IZone.cs
@@ -55,9 +55,6 @@ namespace Perpetuum.Zones
         IRelicManager RelicManager { get; }
         IZoneEffectHandler ZoneEffectHandler { get; }
 
-        [CanBeNull]
-        IStrongholdPlayerStateManager PlayerStateManager { get; }
-
         IZoneUnitService UnitService { get; }
         IZoneEnterQueueService EnterQueueService { get; }
 

--- a/src/Perpetuum/Zones/IZone.cs
+++ b/src/Perpetuum/Zones/IZone.cs
@@ -6,6 +6,7 @@ using Perpetuum.Groups.Corporations;
 using Perpetuum.Log;
 using Perpetuum.Players;
 using Perpetuum.Services.Relics;
+using Perpetuum.Services.Strongholds;
 using Perpetuum.Services.Weather;
 using Perpetuum.Units;
 using Perpetuum.Zones.Beams;
@@ -53,6 +54,9 @@ namespace Perpetuum.Zones
         MiningLogHandler MiningLogHandler { get; }
         IRelicManager RelicManager { get; }
         IZoneEffectHandler ZoneEffectHandler { get; }
+
+        [CanBeNull]
+        IStrongholdPlayerStateManager PlayerStateManager { get; }
 
         IZoneUnitService UnitService { get; }
         IZoneEnterQueueService EnterQueueService { get; }

--- a/src/Perpetuum/Zones/Zone.cs
+++ b/src/Perpetuum/Zones/Zone.cs
@@ -207,7 +207,7 @@ namespace Perpetuum.Zones
             if (unit is Player player)
             {
                 ImmutableInterlocked.TryAdd(ref _players, player.Eid, player);
-                PlayerStateManager?.OnPlayerEnterZone(player);
+                //PlayerStateManager?.OnPlayerEnterZone(player);
             }
 
             unit.Updated += OnUnitUpdated;
@@ -243,7 +243,7 @@ namespace Perpetuum.Zones
             if (u is Player player)
             {
                 ImmutableInterlocked.TryRemove(ref _players, player.Eid, out player);
-                PlayerStateManager?.OnPlayerExitZone(player);
+                //PlayerStateManager?.OnPlayerExitZone(player);
             }
 
             u.Updated -= OnUnitUpdated;

--- a/src/Perpetuum/Zones/Zone.cs
+++ b/src/Perpetuum/Zones/Zone.cs
@@ -207,7 +207,7 @@ namespace Perpetuum.Zones
             if (unit is Player player)
             {
                 ImmutableInterlocked.TryAdd(ref _players, player.Eid, player);
-                //PlayerStateManager?.OnPlayerEnterZone(player);
+                PlayerStateManager?.OnPlayerEnterZone(player);
             }
 
             unit.Updated += OnUnitUpdated;
@@ -243,7 +243,7 @@ namespace Perpetuum.Zones
             if (u is Player player)
             {
                 ImmutableInterlocked.TryRemove(ref _players, player.Eid, out player);
-                //PlayerStateManager?.OnPlayerExitZone(player);
+                PlayerStateManager?.OnPlayerExitZone(player);
             }
 
             u.Updated -= OnUnitUpdated;

--- a/src/Perpetuum/Zones/Zone.cs
+++ b/src/Perpetuum/Zones/Zone.cs
@@ -205,7 +205,10 @@ namespace Perpetuum.Zones
                 return;
 
             if (unit is Player player)
+            {
                 ImmutableInterlocked.TryAdd(ref _players, player.Eid, player);
+                PlayerStateManager?.OnPlayerEnterZone(player);
+            }
 
             unit.Updated += OnUnitUpdated;
             unit.Dead += OnUnitDead;
@@ -238,7 +241,10 @@ namespace Perpetuum.Zones
                 return;
 
             if (u is Player player)
+            {
                 ImmutableInterlocked.TryRemove(ref _players, player.Eid, out player);
+                PlayerStateManager?.OnPlayerExitZone(player);
+            }
 
             u.Updated -= OnUnitUpdated;
             Logger.Info($"Unit exited from zone. zone:{Id} eid = {u.InfoString} ({u.CurrentPosition})");
@@ -325,7 +331,6 @@ namespace Perpetuum.Zones
 
             RiftManager?.Update(time);
             RelicManager?.Update(time);
-            PlayerStateManager?.Update(time);
             MiningLogHandler.Update(time);
             MeasureUpdate(time);
         }

--- a/src/Perpetuum/Zones/Zone.cs
+++ b/src/Perpetuum/Zones/Zone.cs
@@ -18,6 +18,7 @@ using Perpetuum.Services.HighScores;
 using Perpetuum.Services.Relics;
 using Perpetuum.Services.RiftSystem;
 using Perpetuum.Services.Sessions;
+using Perpetuum.Services.Strongholds;
 using Perpetuum.Services.Weather;
 using Perpetuum.Timers;
 using Perpetuum.Units;
@@ -72,6 +73,9 @@ namespace Perpetuum.Zones
 
         [CanBeNull]
         public IRelicManager RelicManager { get; set; }
+
+        [CanBeNull]
+        public IStrongholdPlayerStateManager PlayerStateManager { get; set; }
 
         public IZoneEnterQueueService EnterQueueService { get; set; }
 
@@ -321,6 +325,7 @@ namespace Perpetuum.Zones
 
             RiftManager?.Update(time);
             RelicManager?.Update(time);
+            PlayerStateManager?.Update(time);
             MiningLogHandler.Update(time);
             MeasureUpdate(time);
         }

--- a/src/Perpetuum/Zones/ZoneConfiguration.cs
+++ b/src/Perpetuum/Zones/ZoneConfiguration.cs
@@ -62,6 +62,8 @@ namespace Perpetuum.Zones
                     MaxDockingBase = record.GetValue<int>("maxdockingbase"),
                     PlantAltitudeScale = record.GetValue<double>("plantaltitudescale"),
                     Note = record.GetValue<string>("note"),
+
+                    TimeLimitMinutes = record.GetValue<int?>("timeLimitMinutes")
                 };
 
                 config.PlantRules = _plantRuleLoader.LoadPlantRulesWithOverrides(config.plantRuleSetId);
@@ -103,6 +105,8 @@ namespace Perpetuum.Zones
 
         public string ListenerAddress { get; set; }
         public int ListenerPort { get; set; }
+
+        public int? TimeLimitMinutes { get; set; }
 
         public ZoneType Type { get; set; }
 


### PR DESCRIPTION
Closes: https://github.com/OpenPerpetuum/PerpetuumServer/issues/279
Requires: https://github.com/OpenPerpetuum/OPDB/pull/277

Introduces a timelimit for any configured stronghold to automatically despawn a player back to their homebase if they remain on the zone.

Update: Figured out how to augment the player entities DynamicProperties.  Adding a timestamp of the expiration time will persist the despawn timer between logins to deal with disconnects and timer resetting.