### PR TITLE
Eventservice optimizations

### DIFF
--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -860,10 +860,6 @@ namespace Perpetuum.Bootstrapper
             RegisterUnit<PBSDockingBase>();
             RegisterUnit<Outpost>().OnActivated(e =>
             {
-                var listener = new AffectOutpostStability(e.Instance);
-                e.Context.Resolve<EventListenerService>().AttachListener(listener);
-
-
 #if (DEBUG)
                 var intrusionWaitTime = TimeRange.FromLength(TimeSpan.FromSeconds(10),TimeSpan.FromSeconds(15));
 #else

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -296,6 +296,7 @@
     <Compile Include="Services\EventServices\EventProcessors\NpcSpawnEventHandlers\NpcReinforcementSpawner.cs" />
     <Compile Include="Services\EventServices\EventProcessors\EnvironmentalEffectHandler.cs" />
     <Compile Include="Services\EventServices\EventProcessors\PortalSpawner.cs" />
+    <Compile Include="Services\EventServices\EventType.cs" />
     <Compile Include="Services\GameTime\GameTimeObserver.cs" />
     <Compile Include="Services\GameTime\GameTimeInfo.cs" />
     <Compile Include="Services\GameTime\GameTimeService.cs" />

--- a/src/Perpetuum/Services/EventServices/EventMessages/EventMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/EventMessage.cs
@@ -1,9 +1,6 @@
 ﻿namespace Perpetuum.Services.EventServices.EventMessages
 {
-    /// <summary>
-    /// A specification Interface for EventMessages
-    /// </summary>
-    public interface EventMessage
-    {
+    public interface IEventMessage {
+        EventType Type { get; }
     }
 }

--- a/src/Perpetuum/Services/EventServices/EventMessages/EventMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/EventMessage.cs
@@ -1,6 +1,7 @@
 ﻿namespace Perpetuum.Services.EventServices.EventMessages
 {
-    public interface IEventMessage {
+    public interface IEventMessage
+    {
         EventType Type { get; }
     }
 }

--- a/src/Perpetuum/Services/EventServices/EventMessages/EventMessageSimple.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/EventMessageSimple.cs
@@ -3,15 +3,14 @@
     /// <summary>
     /// A Simple EventMessage stub with string content, mostly to demonstrate usage
     /// </summary>
-    public class EventMessageSimple : EventMessage
+    public class EventMessageSimple : IEventMessage
     {
+        public EventType Type => EventType.undefined;
         private string _content;
-
         public EventMessageSimple(string payload)
         {
             _content = payload;
         }
-
         public string GetMessage()
         {
             return _content;

--- a/src/Perpetuum/Services/EventServices/EventMessages/GameTimeMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/GameTimeMessage.cs
@@ -2,8 +2,9 @@
 
 namespace Perpetuum.Services.EventServices.EventMessages
 {
-    public class GameTimeMessage : EventMessage
+    public class GameTimeMessage : IEventMessage
     {
+        public EventType Type => EventType.Environmental;
         public GameTimeInfo TimeInfo { get; private set; }
         public GameTimeMessage(GameTimeInfo time)
         {

--- a/src/Perpetuum/Services/EventServices/EventMessages/NpcEventMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/NpcEventMessage.cs
@@ -7,8 +7,9 @@ namespace Perpetuum.Services.EventServices.EventMessages
     /// <summary>
     /// EventMessage sent by an NPC
     /// </summary>
-    public class NpcMessage : EventMessage
+    public class NpcMessage : IEventMessage
     {
+        public EventType Type => EventType.NpcChat;
         private string _content;
         private readonly Unit _source;
 

--- a/src/Perpetuum/Services/EventServices/EventMessages/NpcReinforcementsMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/NpcReinforcementsMessage.cs
@@ -2,8 +2,10 @@
 
 namespace Perpetuum.Services.EventServices.EventMessages
 {
-    public class NpcReinforcementsMessage : EventMessage
+    public class NpcReinforcementsMessage : IEventMessage
     {
+        public EventType Type => EventType.NpcReinforce;
+
         public Npc Npc { get; }
         public int ZoneId { get; }
 

--- a/src/Perpetuum/Services/EventServices/EventMessages/OreNpcSpawnMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/OreNpcSpawnMessage.cs
@@ -8,8 +8,10 @@ namespace Perpetuum.Services.EventServices.EventMessages
         Removed
     }
 
-    public class OreNpcSpawnMessage : EventMessage
+    public class OreNpcSpawnMessage : IEventMessage
     {
+        public EventType Type => EventType.NpcOre;
+
         public OreNodeState NodeState { get; }
         public MineralNode Node { get; }
         public int ZoneId { get; }

--- a/src/Perpetuum/Services/EventServices/EventMessages/SpawnPortalMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/SpawnPortalMessage.cs
@@ -2,8 +2,10 @@
 
 namespace Perpetuum.Services.EventServices.EventMessages
 {
-    public class SpawnPortalMessage : EventMessage
+    public class SpawnPortalMessage : IEventMessage
     {
+        public EventType Type => EventType.PortalSpawn;
+
         public Position SourcePosition { get; private set; }
         public int SourceZone { get; private set; }
         public CustomRiftConfig RiftConfig { get; private set; }

--- a/src/Perpetuum/Services/EventServices/EventMessages/StabilityEffectMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/StabilityEffectMessage.cs
@@ -8,8 +8,10 @@ namespace Perpetuum.Services.EventServices.EventMessages
     /// <summary>
     /// An EventMessage of an event to alter Outpost stability (SAP)
     /// </summary>
-    public class StabilityAffectingEvent : EventMessage
+    public class StabilityAffectingEvent : IEventMessage
     {
+        public EventType Type => EventType.OutpostStability;
+
         public Corporation Winner { get; private set; }
         public Outpost Outpost { get; private set; }
         public bool OverrideRelations { get; private set; }

--- a/src/Perpetuum/Services/EventServices/EventMessages/WeatherEventMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/WeatherEventMessage.cs
@@ -2,8 +2,9 @@
 
 namespace Perpetuum.Services.EventServices.EventMessages
 {
-    public class WeatherEventMessage : EventMessage
+    public class WeatherEventMessage : IEventMessage
     {
+        public EventType Type => EventType.Environmental;
         public WeatherInfo Weather { get; private set; }
         public int ZoneId { get; private set; }
         public WeatherEventMessage(WeatherInfo weather, int zoneId)

--- a/src/Perpetuum/Services/EventServices/EventProcessors/AffectOutpostStability.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/AffectOutpostStability.cs
@@ -8,7 +8,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
     /// </summary>
     public class AffectOutpostStability : EventProcessor
     {
-        private Outpost _outpost;
+        private readonly Outpost _outpost;
         public AffectOutpostStability(Outpost outpost)
         {
             _outpost = outpost;

--- a/src/Perpetuum/Services/EventServices/EventProcessors/AffectOutpostStability.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/AffectOutpostStability.cs
@@ -1,6 +1,5 @@
 ﻿using Perpetuum.Services.EventServices.EventMessages;
 using Perpetuum.Zones.Intrusion;
-using System;
 
 namespace Perpetuum.Services.EventServices.EventProcessors
 {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/AffectOutpostStability.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/AffectOutpostStability.cs
@@ -1,5 +1,6 @@
 ﻿using Perpetuum.Services.EventServices.EventMessages;
 using Perpetuum.Zones.Intrusion;
+using System;
 
 namespace Perpetuum.Services.EventServices.EventProcessors
 {
@@ -14,7 +15,9 @@ namespace Perpetuum.Services.EventServices.EventProcessors
             _outpost = outpost;
         }
 
-        public override void HandleMessage(EventMessage value)
+        public override EventType Type => EventType.OutpostStability;
+
+        public override void HandleMessage(IEventMessage value)
         {
             if (value is StabilityAffectingEvent msg)
             {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/ChatEcho.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/ChatEcho.cs
@@ -4,6 +4,7 @@ using Perpetuum.Services.EventServices.EventMessages;
 using Perpetuum.Services.EventServices.EventProcessors;
 using Perpetuum.Units;
 using Perpetuum.Zones;
+using System;
 
 namespace Perpetuum.Services.EventServices
 {
@@ -14,7 +15,7 @@ namespace Perpetuum.Services.EventServices
     {
         private readonly IChannelManager _channelManager;
         private const string SENDER_CHARACTER_NICKNAME = "[OPP] Announcer";
-        private Character _announcer;
+        private readonly Character _announcer;
 
         public ChatEcho(IChannelManager channelManager)
         {
@@ -22,7 +23,8 @@ namespace Perpetuum.Services.EventServices
             _channelManager = channelManager;
         }
 
-        public override void HandleMessage(EventMessage value)
+        public override EventType Type => EventType.undefined;
+        public override void HandleMessage(IEventMessage value)
         {
             if (value is EventMessageSimple msg)
             {
@@ -40,14 +42,15 @@ namespace Perpetuum.Services.EventServices
     public class NpcChatEcho : EventProcessor
     {
         private const string SENDER_CHARACTER_NICKNAME = "[OPP] Announcer"; //TODO "Nian" character
-        private Character _announcer;
+        private readonly Character _announcer;
 
         public NpcChatEcho()
         {
             _announcer = Character.GetByNick(SENDER_CHARACTER_NICKNAME);
         }
 
-        public override void HandleMessage(EventMessage value)
+        public override EventType Type => EventType.NpcChat;
+        public override void HandleMessage(IEventMessage value)
         {
             if (value is NpcMessage msg)
             {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/ChatEcho.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/ChatEcho.cs
@@ -4,7 +4,6 @@ using Perpetuum.Services.EventServices.EventMessages;
 using Perpetuum.Services.EventServices.EventProcessors;
 using Perpetuum.Units;
 using Perpetuum.Zones;
-using System;
 
 namespace Perpetuum.Services.EventServices
 {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/EnvironmentalEffectHandler.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/EnvironmentalEffectHandler.cs
@@ -71,7 +71,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
             }
         }
 
-        private bool TryGetWeatherMessage(EventMessage value)
+        private bool TryGetWeatherMessage(IEventMessage value)
         {
             var msg = value as WeatherEventMessage;
             var isValidMsg = msg != null && msg.ZoneId == _zone.Id;
@@ -82,7 +82,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
             return isValidMsg;
         }
 
-        private bool TryGetGameTimeMessage(EventMessage value)
+        private bool TryGetGameTimeMessage(IEventMessage value)
         {
             var msg = value as GameTimeMessage;
             var isValidMsg = msg != null;
@@ -93,7 +93,8 @@ namespace Perpetuum.Services.EventServices.EventProcessors
             return isValidMsg;
         }
 
-        public override void HandleMessage(EventMessage value)
+        public override EventType Type => EventType.Environmental;
+        public override void HandleMessage(IEventMessage value)
         {
             var stateChange = TryGetWeatherMessage(value) || TryGetGameTimeMessage(value);
             if (stateChange)

--- a/src/Perpetuum/Services/EventServices/EventProcessors/EventProcessor.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/EventProcessor.cs
@@ -3,18 +3,23 @@ using System;
 
 namespace Perpetuum.Services.EventServices.EventProcessors
 {
-    public interface IEventProcessor : IObserver<EventMessage>
+    public interface IEventProcessor : IObserver<IEventMessage>
     {
-        void HandleMessage(EventMessage value);
+        void HandleMessage(IEventMessage value);
+        EventType Type { get; }
     }
 
     public abstract class EventProcessor : IEventProcessor
     {
-        public abstract void HandleMessage(EventMessage value);
+        public abstract EventType Type { get; }
+        public abstract void HandleMessage(IEventMessage value);
 
-        public void OnNext(EventMessage value)
+        public void OnNext(IEventMessage value)
         {
-            HandleMessage(value);
+            if (value.Type == Type)
+            {
+                HandleMessage(value);
+            }
         }
 
         public void OnCompleted()

--- a/src/Perpetuum/Services/EventServices/EventProcessors/EventProcessor.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/EventProcessor.cs
@@ -16,10 +16,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
 
         public void OnNext(IEventMessage value)
         {
-            if (value.Type == Type)
-            {
-                HandleMessage(value);
-            }
+            HandleMessage(value);
         }
 
         public void OnCompleted()

--- a/src/Perpetuum/Services/EventServices/EventProcessors/EventProcessor.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/EventProcessor.cs
@@ -12,6 +12,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
     public abstract class EventProcessor : IEventProcessor
     {
         public abstract EventType Type { get; }
+
         public abstract void HandleMessage(IEventMessage value);
 
         public void OnNext(IEventMessage value)

--- a/src/Perpetuum/Services/EventServices/EventProcessors/NpcSpawnEventHandlers/NpcReinforcementSpawner.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/NpcSpawnEventHandlers/NpcReinforcementSpawner.cs
@@ -18,6 +18,8 @@ namespace Perpetuum.Services.EventServices.EventProcessors.NpcSpawnEventHandlers
         protected override TimeSpan SPAWN_LIFETIME { get { return TimeSpan.FromMinutes(30); } }
         protected override int MAX_SPAWN_DIST { get { return 10; } }
 
+        public override EventType Type => EventType.NpcReinforce;
+
         private readonly IDictionary<NpcBossInfo, INpcReinforcements> _reinforcementsByNpc = new Dictionary<NpcBossInfo, INpcReinforcements>();
         public NpcReinforcementSpawner(IZone zone, INpcReinforcementsRepository reinforcementsRepo) : base(zone, reinforcementsRepo) { }
 
@@ -26,7 +28,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors.NpcSpawnEventHandlers
             return _reinforcementsByNpc.Where(p => p.Value.HasActivePresence(presence)).Select(p => p.Value);
         }
 
-        protected override bool CheckMessage(EventMessage inMsg, out NpcReinforcementsMessage msg)
+        protected override bool CheckMessage(IEventMessage inMsg, out NpcReinforcementsMessage msg)
         {
             if (inMsg is NpcReinforcementsMessage message && _zone.Id == message.ZoneId)
             {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/NpcSpawnEventHandlers/NpcSpawnEventHandler.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/NpcSpawnEventHandlers/NpcSpawnEventHandler.cs
@@ -14,7 +14,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors.NpcSpawnEventHandlers
     /// Common functions and event handling procedure for NpcReinforcement related events
     /// </summary>
     /// <typeparam name="T">EventMessage</typeparam>
-    public abstract class NpcSpawnEventHandler<T> : EventProcessor where T : EventMessage
+    public abstract class NpcSpawnEventHandler<T> : EventProcessor where T : IEventMessage
     {
         protected abstract TimeSpan SPAWN_DELAY { get; }
         protected abstract TimeSpan SPAWN_LIFETIME { get; }
@@ -30,7 +30,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors.NpcSpawnEventHandlers
 
         protected abstract IEnumerable<INpcReinforcements> GetActiveReinforcments(Presence presence);
 
-        protected abstract bool CheckMessage(EventMessage inMsg, out T msg);
+        protected abstract bool CheckMessage(IEventMessage inMsg, out T msg);
 
         protected abstract void CheckReinforcements(T msg);
 
@@ -81,7 +81,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors.NpcSpawnEventHandlers
 
         private bool _spawning = false;
 
-        public override void HandleMessage(EventMessage value)
+        public override void HandleMessage(IEventMessage value)
         {
             if (CheckMessage(value, out T msg))
             {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/NpcSpawnEventHandlers/OreNPCSpawner.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/NpcSpawnEventHandlers/OreNPCSpawner.cs
@@ -21,6 +21,8 @@ namespace Perpetuum.Services.EventServices.EventProcessors.NpcSpawnEventHandlers
 
         private const int MIN_SPAWN_DIST_TOLERANCE = 30;
 
+        public override EventType Type => EventType.NpcOre;
+
         private readonly IDictionary<MineralNode, INpcReinforcements> _reinforcementsByNode = new Dictionary<MineralNode, INpcReinforcements>();
         private readonly IEnumerable<IMineralConfiguration> _mineralConfigs;
 
@@ -34,7 +36,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors.NpcSpawnEventHandlers
             return _reinforcementsByNode.Where(p => p.Value.HasActivePresence(presence)).Select(p => p.Value);
         }
 
-        protected override bool CheckMessage(EventMessage inMsg, out OreNpcSpawnMessage msg)
+        protected override bool CheckMessage(IEventMessage inMsg, out OreNpcSpawnMessage msg)
         {
             if (inMsg is OreNpcSpawnMessage message && _zone.Id == message.ZoneId)
             {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/PortalSpawner.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/PortalSpawner.cs
@@ -1,4 +1,5 @@
-﻿using Perpetuum.EntityFramework;
+﻿using System;
+using Perpetuum.EntityFramework;
 using Perpetuum.ExportedTypes;
 using Perpetuum.Services.EventServices.EventMessages;
 using Perpetuum.Services.RiftSystem;
@@ -10,6 +11,8 @@ namespace Perpetuum.Services.EventServices.EventProcessors
     {
         private readonly IEntityServices _entityServices;
         private readonly IZoneManager _zoneManager;
+
+        public override EventType Type => EventType.PortalSpawn;
 
         public PortalSpawner(IEntityServices entityServices, IZoneManager zoneManager)
         {
@@ -26,7 +29,7 @@ namespace Perpetuum.Services.EventServices.EventProcessors
             return true;
         }
 
-        public override void HandleMessage(EventMessage value)
+        public override void HandleMessage(IEventMessage value)
         {
             if (value is SpawnPortalMessage msg)
             {

--- a/src/Perpetuum/Services/EventServices/EventProcessors/PortalSpawner.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/PortalSpawner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Perpetuum.EntityFramework;
+﻿using Perpetuum.EntityFramework;
 using Perpetuum.ExportedTypes;
 using Perpetuum.Services.EventServices.EventMessages;
 using Perpetuum.Services.RiftSystem;

--- a/src/Perpetuum/Services/EventServices/EventType.cs
+++ b/src/Perpetuum/Services/EventServices/EventType.cs
@@ -1,0 +1,14 @@
+﻿namespace Perpetuum.Services.EventServices
+{
+    public enum EventType
+    {
+        undefined,
+        ChatEcho,
+        OutpostStability,
+        NpcChat,
+        NpcOre,
+        NpcReinforce,
+        Environmental,
+        PortalSpawn,
+    }
+}

--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -17,8 +17,8 @@ using Perpetuum.Log;
 using Perpetuum.Services.Channels;
 using Perpetuum.Services.EventServices;
 using Perpetuum.Services.EventServices.EventMessages;
+using Perpetuum.Services.EventServices.EventProcessors;
 using Perpetuum.Services.Looting;
-using Perpetuum.Services.Relics;
 using Perpetuum.Timers;
 using Perpetuum.Units.DockingBases;
 using Perpetuum.Zones.Effects;
@@ -76,6 +76,11 @@ namespace Perpetuum.Zones.Intrusion
             _lootService = lootService;
             _eventChannel = eventChannel;
             _decay = new OutpostDecay(_eventChannel, this);
+        }
+
+        private void InitStabilityListener()
+        {
+            _eventChannel.AttachListener(new AffectOutpostStability(this));
         }
 
         public void PublishSAPEvent(StabilityAffectingEvent eventMsg)
@@ -311,6 +316,7 @@ namespace Perpetuum.Zones.Intrusion
         {
             base.OnEnterZone(zone, enterType);
             RefreshEffectBonus();
+            InitStabilityListener();
         }
 
         private bool _enabled = true;

--- a/src/Perpetuum/Zones/NpcSystem/NPCBossInfo.cs
+++ b/src/Perpetuum/Zones/NpcSystem/NPCBossInfo.cs
@@ -234,7 +234,7 @@ namespace Perpetuum.Zones.NpcSystem
         {
             if (!msg.IsNullOrEmpty())
             {
-                EventMessage eventMessage = new NpcMessage(msg, src);
+                IEventMessage eventMessage = new NpcMessage(msg, src);
                 Task.Run(() => eventChannel.PublishMessage(eventMessage));
             }
         }


### PR DESCRIPTION
Before all observers would get a message from the Eventservice and type check if the message was a type that they will process.
Because most of the services are 1:1 for each event, and as the types and quantities of each grow, this becomes a scale issue.

Now using the key `EventType` an observing `EventProcessor` will only receive messages with that EventType property, dramatically reducing the size of the notification loop for each message sent.

Also includes a fix for `AffectOutpostStability` getting subscribed when empty Outpost objects were being created.

Outcomes:
 - only 9 instances of `AffectOutpostStability` 1 for each outpost for lifetime of server (instead of increasing linearly with every SAP spawn)
 - `EventListenerService` observers notified only for relevant message type they are listening for.

Closes: #242 
Closes: #246