### PR TITLE
Player teleporting to -1, -1 on Spawn in grown wall (OpenPerpetuum#300)

### DIFF
--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -1029,7 +1029,10 @@ namespace Perpetuum.Players
 
                 // keresunk neki valami jo poziciot
                 var finder = new ClosestWalkablePositionFinder(zone, spawnPosition, player);
-                var validPosition = finder.FindOrThrow();
+                if(!zone.IsWalkable(spawnPosition))
+                {
+                    finder.Find(out spawnPosition);
+                }
 
                 // parentoljuk a zonahoz <<< NAGYON FONTOS - TILOS MASHOGY kulonben bennmaradnak a (pbs) bazison a robotok, es pl letorlodnek amikor kilovik a bazist
                 var zoneStorage = zone.Configuration.GetStorage();
@@ -1047,7 +1050,7 @@ namespace Perpetuum.Players
                     player.CorporationEid = character.CorporationEid;
                     zone.SetGang(player);
 
-                    player.AddToZone(zone,validPosition,zoneEnterType);
+                    player.AddToZone(zone,spawnPosition,zoneEnterType);
                     player.ApplyInvulnerableEffect();
                 });
 


### PR DESCRIPTION
I was able to replicate the issue on my local server. The player object was moved to -1, -1 due to a null position being returned by the method that was being called.

The position check code in player.cs was calling the incorrect method for correctly finding a new position to place the player. Rectified the method call and  was unable to replicate the issue after the fix was made.