### PR TITLE
Aggressive npc threat adding fix

### DIFF
--- a/src/Perpetuum/Zones/NpcSystem/Npc.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Npc.cs
@@ -1237,7 +1237,6 @@ namespace Perpetuum.Zones.NpcSystem
         /// <summary>
         /// This determines if threat can be added to a target based on the following:
         ///  - Is the target already on the threat manager
-        ///  - Or is the npc aggressive and within aggrorange
         ///  - Or is the npc non-passive and the Threat is of some defined type
         /// </summary>
         /// <param name="target">Unit target</param>
@@ -1248,16 +1247,10 @@ namespace Perpetuum.Zones.NpcSystem
             if (_threatManager.Contains(target))
                 return true;
 
-            switch (Behavior.Type)
-            {
-                case NpcBehaviorType.Passive:
-                    return false;
-                case NpcBehaviorType.Neutral:
-                    {
-                        return threat.type != ThreatType.Undefined;
-                    }
-            }
-            return IsInAggroRange(target);
+            if (Behavior.Type == NpcBehaviorType.Passive)
+                return false;
+
+            return threat.type != ThreatType.Undefined;
         }
 
         private void AddBodyPullThreat(Unit enemy)


### PR DESCRIPTION
Closes: #317 

The distance check for `IsInAggroRange` was redundant to the check already performed in the `BodyPullThreatHelper` and was potentially preventing threats from being added to Red npcs being aggressed with other indirect threats which use this filter in a extensionmethod before adding threats.
