### PR TITLE
Gamma Market Visibility

### DIFF
--- a/src/Perpetuum.RequestHandlers/Markets/MarketItemsInRange.cs
+++ b/src/Perpetuum.RequestHandlers/Markets/MarketItemsInRange.cs
@@ -47,13 +47,13 @@ namespace Perpetuum.RequestHandlers.Markets
             //exclude training market
             //include corp orders if character in private corp
             //include normal orders (non corp)
-            var orders = _marketOrderRepository.GetAllByDefinition(itemDefinition).Where(r => r.marketEID != trainingMarketEid && (r.forMembersOf == corporationEid || r.forMembersOf == null)).ToArray();
+            //var orders = _marketOrderRepository.GetAllByDefinition(itemDefinition).Where(r => r.marketEID != trainingMarketEid && (r.forMembersOf == corporationEid || r.forMembersOf == null)).ToArray();
 
 
             //ez szabalyozza le, hogy nem latszanak a pbs marketek
             //itt lehet ugyeskedni
             //filtered markets
-            //var orders = repo.GetByMarketEids(MarketHandler.GetAllDefaultMarketsEids(), itemDefinition, request.character.CorporationEid).ToArray();
+            var orders = _marketOrderRepository.GetByMarketEids(_marketHandler.GetAllVisibleMarketsFor(character), itemDefinition, corporationEid).ToArray();
 
             var orderDict = new Dictionary<string, object>(orders.Length);
             var counter = 0;

--- a/src/Perpetuum/Services/MarketEngine/Market.cs
+++ b/src/Perpetuum/Services/MarketEngine/Market.cs
@@ -97,7 +97,12 @@ namespace Perpetuum.Services.MarketEngine
 
         public bool IsOnGammaZone()
         {
-            return GetDockingBase().IsOnGammaZone();
+            return GetDockingBase()?.IsOnGammaZone() ?? false;
+        }
+
+        public bool IsVisible(Character character)
+        {
+            return GetDockingBase()?.IsVisible(character) ?? false;
         }
 
         public bool IsPlayerControlledMarketTax()

--- a/src/Perpetuum/Services/MarketEngine/MarketOrderRepository.cs
+++ b/src/Perpetuum/Services/MarketEngine/MarketOrderRepository.cs
@@ -19,7 +19,7 @@ namespace Perpetuum.Services.MarketEngine
         MarketOrder GetHighestBuyOrder(int itemDefinition, double price, long submitterEid, Market market, long forMembersOf);
 
         IEnumerable<MarketOrder> GetByMarket(Market market);
-        IEnumerable<MarketOrder> GetByMarketEids(IEnumerable<long> marketEids, int itemDefinition, long forMembersOf);
+        IEnumerable<MarketOrder> GetByMarketEids(IEnumerable<long> marketEids, int itemDefinition, long? forMembersOf);
         IEnumerable<MarketOrder> GetByCharacter(Character character);
         IEnumerable<MarketOrder> GetByDefinition(int itemDefinition, long forMembersOf, Market market);
         IEnumerable<MarketOrder> GetExpiredOrders(TimeSpan duration);
@@ -115,7 +115,7 @@ namespace Perpetuum.Services.MarketEngine
                            .ToArray();
         }
 
-        public IEnumerable<MarketOrder> GetByMarketEids(IEnumerable<long> marketEids, int itemDefinition, long forMembersOf)
+        public IEnumerable<MarketOrder> GetByMarketEids(IEnumerable<long> marketEids, int itemDefinition, long? forMembersOf)
         {
             var marketEidsString = marketEids.ArrayToString();
 

--- a/src/Perpetuum/Services/MarketEngine/MarketPriceCollector.cs
+++ b/src/Perpetuum/Services/MarketEngine/MarketPriceCollector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using Perpetuum.Accounting.Characters;
 using Perpetuum.EntityFramework;
 using Perpetuum.Log;
 
@@ -27,6 +28,11 @@ namespace Perpetuum.Services.MarketEngine
         public bool IsTrainingMarket => Market.IsOnTrainingZone();
 
         public bool IsGammaMarket => Market.IsOnGammaZone();
+
+        public bool IsVisible(Character character)
+        {
+            return Market.IsVisible(character);
+        }
 
         /// <summary>
         /// Filters and inserts an average price entry

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -271,6 +271,11 @@ namespace Perpetuum.Units.DockingBases
             return false;
         }
 
+        public virtual bool IsVisible(Character character)
+        {
+            return true;
+        }
+
         public void AddCentralBank(TransactionType transactionType, double amount)
         {
             amount = Math.Abs(amount);

--- a/src/Perpetuum/Zones/Gates/Gate.cs
+++ b/src/Perpetuum/Zones/Gates/Gate.cs
@@ -256,5 +256,15 @@ namespace Perpetuum.Zones.Gates
                 source.ApplyPvPEffect();
             }
         }
+
+        public bool IsVisible(Character character)
+        {
+            Corporation.GetCorporationEidAndRoleFromSql(character, out long corporationEid, out CorporationRole role);
+            if (Owner == corporationEid)
+            {
+                return role.IsAnyRole(CorporationRole.CEO, CorporationRole.DeputyCEO, CorporationRole.viewPBS);
+            }
+            return false;
+        }
     }
 }

--- a/src/Perpetuum/Zones/PBS/DockingBases/PBSDockingBase.cs
+++ b/src/Perpetuum/Zones/PBS/DockingBases/PBSDockingBase.cs
@@ -456,6 +456,26 @@ namespace Perpetuum.Zones.PBS.DockingBases
             return true;
         }
 
+        public override bool IsVisible(Character character)
+        {
+            if (DockingBaseMapVisibility == PBSDockingBaseVisibility.open)
+                return true;
+
+            Corporation.GetCorporationEidAndRoleFromSql(character, out long corporationEid, out CorporationRole role);
+            if (Owner == corporationEid)
+            {
+                if (DockingBaseMapVisibility == PBSDockingBaseVisibility.corporation)
+                {
+                    return true;
+                }
+                else if (DockingBaseMapVisibility == PBSDockingBaseVisibility.hidden)
+                {
+                    return role.IsAnyRole(CorporationRole.CEO, CorporationRole.DeputyCEO, CorporationRole.viewPBS);
+                }
+            }
+            return false;
+        }
+
         private bool _trashWasKilled;
         public void TrashMe()
         {

--- a/src/Perpetuum/Zones/PBS/DockingBases/PBSDockingBase.cs
+++ b/src/Perpetuum/Zones/PBS/DockingBases/PBSDockingBase.cs
@@ -142,7 +142,8 @@ namespace Perpetuum.Zones.PBS.DockingBases
             _pbsReinforceHandler.Init();
             _pbsTerritorialVisibilityHelper.Init();
 
-            ClearChildren(); //ez azert kell, hogy a zonan ne legyenek gyerekei semmikepp
+            //OPP: The following line is commented because it broke the BaseListFacilities command.
+            // ClearChildren(); //ez azert kell, hogy a zonan ne legyenek gyerekei semmikepp
             Parent = 0; //ez azert kell, hogy a bazison levo kontenerek megtalaljak, mint root
             base.OnEnterZone(zone, enterType);
         }


### PR DESCRIPTION
Requires: https://github.com/OpenPerpetuum/PerpetuumServer/pull/333 (as a pre-req for any gamma market stuff)
Closes: #332 
The jury is still out on how it used to be.  Existing code suggests that all Gamma orders are invisible remotely.
But let's enhance that:
This PR now features remote market order visibility for Gamma bases that a character can *see* (meaning the base is visible to them via the `PBSDockingBaseVisibility` value)

This also increase the fetch speed on the `MarketItemsInRange` command because it is not doing 4 joins like the `GetAllByDefinition` method, and it is not filtering the list after the fact in memory cleaning out training orders and corp order logic.
It does have an initial query for markets (in memory), but I chose to cache this as remote market browsing generates a lot of rapid requests, its worth caching just for a few minutes.

Also some related refactoring to encapsulate the visibility logic and reduce the frequency of the corp role query in that extension method.