### PR TITLE
Fix portalspawn

### DIFF
--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -138,7 +138,7 @@ namespace Perpetuum.Players
         private readonly PlayerMovement _movement;
         private CombatLogger _combatLogger;
         private PlayerMoveCheckQueue _check;
-        private StrongholdPlayerDespawnHelper _despawnHelper;
+        private CancellableDespawnHelper _despawnHelper;
 
         public Player(IExtensionReader extensionReader,
             ICorporationManager corporationManager,
@@ -329,7 +329,7 @@ namespace Perpetuum.Players
         {
             if (_despawnHelper == null)
             {
-                _despawnHelper = StrongholdPlayerDespawnHelper.Create(this, time);
+                _despawnHelper = CancellableDespawnHelper.Create(this, time);
                 _despawnHelper.DespawnStrategy = strategy;
             }
         }

--- a/src/Perpetuum/Services/EventServices/EventMessages/SpawnPortalMessage.cs
+++ b/src/Perpetuum/Services/EventServices/EventMessages/SpawnPortalMessage.cs
@@ -15,5 +15,10 @@ namespace Perpetuum.Services.EventServices.EventMessages
             SourceZone = sourceZone;
             RiftConfig = riftConfig;
         }
+
+        public override string ToString()
+        {
+            return $"SpawnPortalMessage:z:{SourceZone};Pos:{SourcePosition};{RiftConfig};";
+        }
     }
 }

--- a/src/Perpetuum/Services/EventServices/EventProcessors/PortalSpawner.cs
+++ b/src/Perpetuum/Services/EventServices/EventProcessors/PortalSpawner.cs
@@ -53,7 +53,6 @@ namespace Perpetuum.Services.EventServices.EventProcessors
         {
             if (value is SpawnPortalMessage msg)
             {
-                Logger.DebugInfo($"{msg}");
                 if (!ValidateMessage(msg))
                 {
                     Logger.Warning($"SpawnPortalMessage was not valid!\n{msg}");

--- a/src/Perpetuum/Services/RiftSystem/CustomRiftConfig.cs
+++ b/src/Perpetuum/Services/RiftSystem/CustomRiftConfig.cs
@@ -108,9 +108,9 @@ namespace Perpetuum.Services.RiftSystem
 
             var targetPos = targetDestination.GetPosition(zoneTarget);
             var rift = riftFactory();
-            rift.AddToZone(zone, sourcePosition, ZoneEnterType.NpcSpawn);
             rift.SetTarget(zoneTarget, targetPos);
             rift.SetConfig(config);
+            rift.AddToZone(zone, sourcePosition, ZoneEnterType.NpcSpawn);
 
             Logger.Info(string.Format("Rift spawned on zone {0} {1} ({2})", zone.Id, rift.ED.Name, rift.CurrentPosition));
             return true;
@@ -148,6 +148,11 @@ namespace Perpetuum.Services.RiftSystem
         public Destination GetDestination()
         {
             return _destinations.GetRandom();
+        }
+
+        public override string ToString()
+        {
+            return $"CustomRiftConfig:id:{Id};n:{Name};l:{Lifespan};u:{MaxUses};";
         }
     }
 

--- a/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
+++ b/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
@@ -1,9 +1,7 @@
 ﻿using Perpetuum.Data;
-using Perpetuum.ExportedTypes;
 using Perpetuum.Players;
 using Perpetuum.Services.EventServices;
 using Perpetuum.Services.EventServices.EventMessages;
-using Perpetuum.Units;
 using Perpetuum.Zones;
 using System;
 
@@ -121,46 +119,4 @@ namespace Perpetuum.Services.Strongholds
             _eventChannel.PublishMessage(new DirectMessage(player.Character, message));
         }
     }
-
-    public class StrongholdPlayerDespawnHelper : UnitDespawnHelper
-    {
-        public override EffectType DespawnEffect
-        {
-            get { return EffectType.effect_stronghold_despawn_timer; }
-        }
-        private StrongholdPlayerDespawnHelper(TimeSpan despawnTime) : base(despawnTime) { }
-
-        private bool _canceled = false;
-        public void Cancel(Unit unit)
-        {
-            _canceled = true;
-            RemoveDespawnEffect(unit);
-        }
-
-        public override void Update(TimeSpan time, Unit unit)
-        {
-            _timer.Update(time).IsPassed(() =>
-            {
-                if (_canceled || EffectLive(unit))
-                    return;
-
-                DespawnStrategy?.Invoke(unit);
-            });
-        }
-
-        private void RemoveDespawnEffect(Unit unit)
-        {
-            unit.EffectHandler.RemoveEffectByToken(_effectToken);
-        }
-
-        public new static StrongholdPlayerDespawnHelper Create(Unit unit, TimeSpan despawnTime)
-        {
-            var helper = new StrongholdPlayerDespawnHelper(despawnTime);
-            helper.ApplyDespawnEffect(unit);
-            return helper;
-        }
-    }
 }
-
-
-

--- a/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
+++ b/src/Perpetuum/Services/Strongholds/StrongholdPlayerStateManager.cs
@@ -124,8 +124,10 @@ namespace Perpetuum.Services.Strongholds
 
     public class StrongholdPlayerDespawnHelper : UnitDespawnHelper
     {
-        private static readonly EffectType DespawnEffect = EffectType.effect_stronghold_despawn_timer;
-
+        public override EffectType DespawnEffect
+        {
+            get { return EffectType.effect_stronghold_despawn_timer; }
+        }
         private StrongholdPlayerDespawnHelper(TimeSpan despawnTime) : base(despawnTime) { }
 
         private bool _canceled = false;
@@ -133,22 +135,6 @@ namespace Perpetuum.Services.Strongholds
         {
             _canceled = true;
             RemoveDespawnEffect(unit);
-        }
-
-        public bool HasEffect(Unit unit)
-        {
-            return unit.EffectHandler.ContainsToken(_effectToken);
-        }
-
-        private bool _detectedEffectApplied = false;
-        private bool EffectLive(Unit unit)
-        {
-            var effectRunning = HasEffect(unit);
-            if (!_detectedEffectApplied)
-            {
-                _detectedEffectApplied = effectRunning;
-            }
-            return _detectedEffectApplied == effectRunning;
         }
 
         public override void Update(TimeSpan time, Unit unit)
@@ -165,12 +151,6 @@ namespace Perpetuum.Services.Strongholds
         private void RemoveDespawnEffect(Unit unit)
         {
             unit.EffectHandler.RemoveEffectByToken(_effectToken);
-        }
-
-        private void ApplyDespawnEffect(Unit unit)
-        {
-            var effectBuilder = unit.NewEffectBuilder().SetType(DespawnEffect).WithDuration(_despawnTime).WithToken(_effectToken);
-            unit.ApplyEffect(effectBuilder);
         }
 
         public new static StrongholdPlayerDespawnHelper Create(Unit unit, TimeSpan despawnTime)

--- a/src/Perpetuum/Zones/Effects/EffectHandler.cs
+++ b/src/Perpetuum/Zones/Effects/EffectHandler.cs
@@ -178,6 +178,11 @@ namespace Perpetuum.Zones.Effects
             Remove(effect);
         }
 
+        public bool ContainsOrPending(EffectToken token)
+        {
+            return ContainsToken(token) || _newEffects.Any(e => e.Token == token);
+        }
+
         public bool ContainsToken(EffectToken token)
         {
             return Effects.Any(e => e.Token == token);


### PR DESCRIPTION
Closes: #338 
Portal may fail to spawn if the npc (or source destination in message) is nonwalkable, so adds retry strategies to find a nearby walkable location.

Also caught case where a portal spawn would be immediately despawned because the effecthandler did not fully apply the despawn effect, which the despawnhelper naively assumes that means it was removed because it expired.