### PR TITLE
Robot module/components IEnum->array

### DIFF
--- a/src/Perpetuum/Robots/Robot.cs
+++ b/src/Perpetuum/Robots/Robot.cs
@@ -59,8 +59,17 @@ namespace Perpetuum.Robots
     {
         protected Robot()
         {
+            InitComponents();
+            InitModules();
             InitLockHander();
             InitProperties();
+        }
+
+        public override void Initialize()
+        {
+            InitComponents();
+            InitModules();
+            base.Initialize();
         }
 
         public RobotHelper RobotHelper { protected get; set; }
@@ -242,7 +251,7 @@ namespace Perpetuum.Robots
             {
                 module.Unequip(targetContainer);
             }
-
+            InitModules();
             if (!withContainer)
                 return;
 
@@ -316,24 +325,41 @@ namespace Perpetuum.Robots
             return RobotComponents.FirstOrDefault(c => c.Type == componentType);
         }
 
-        public IEnumerable<ActiveModule> ActiveModules
+        private Lazy<IEnumerable<Module>> _modules;
+        private Lazy<IEnumerable<ActiveModule>> _activeModules;
+        private void InitModules()
         {
-            get { return Modules.OfType<ActiveModule>(); }
+            _modules = new Lazy<IEnumerable<Module>>(() => RobotComponents.SelectMany(c => c.Modules).ToArray());
+            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Modules.OfType<ActiveModule>().ToArray());
         }
 
         public IEnumerable<Module> Modules
         {
-            get { return RobotComponents.SelectMany(c => c.Modules); }
+            get { return _modules.Value; }
+        }
+
+        public IEnumerable<ActiveModule> ActiveModules
+        {
+            get { return _activeModules.Value; }
+        }
+
+        private Lazy<IEnumerable<Item>> _components;
+        private Lazy<IEnumerable<RobotComponent>> _robotComponents;
+        private void InitComponents()
+        {
+
+            _components = new Lazy<IEnumerable<Item>>(() => Children.OfType<Item>().ToArray());
+            _robotComponents = new Lazy<IEnumerable<RobotComponent>>(() => Components.OfType<RobotComponent>().ToArray());
         }
 
         public IEnumerable<Item> Components
         {
-            get { return Children.OfType<Item>(); }
+            get { return _components.Value; }
         }
 
         public IEnumerable<RobotComponent> RobotComponents
         {
-            get { return Components.OfType<RobotComponent>(); }
+            get { return _robotComponents.Value; }
         }
 
         public void CheckEnergySystemAndThrowIfFailed()

--- a/src/Perpetuum/Robots/Robot.cs
+++ b/src/Perpetuum/Robots/Robot.cs
@@ -59,11 +59,14 @@ namespace Perpetuum.Robots
     {
         protected Robot()
         {
-            InitComponents();
-            InitModules();
             InitLockHander();
             InitProperties();
         }
+
+        public RobotHelper RobotHelper { protected get; set; }
+        public InsuranceHelper InsuranceHelper { protected get; set; }
+
+        public RobotTemplate Template { get; set; }
 
         public override void Initialize()
         {
@@ -72,10 +75,21 @@ namespace Perpetuum.Robots
             base.Initialize();
         }
 
-        public RobotHelper RobotHelper { protected get; set; }
-        public InsuranceHelper InsuranceHelper { protected get; set; }
+        private Lazy<IEnumerable<Module>> _modules;
+        private Lazy<IEnumerable<ActiveModule>> _activeModules;
+        private void InitModules()
+        {
+            _modules = new Lazy<IEnumerable<Module>>(() => RobotComponents.SelectMany(c => c.Modules).ToArray());
+            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Modules.OfType<ActiveModule>().ToArray());
+        }
 
-        public RobotTemplate Template { get; set; }
+        private Lazy<IEnumerable<Item>> _components;
+        private Lazy<IEnumerable<RobotComponent>> _robotComponents;
+        private void InitComponents()
+        {
+            _components = new Lazy<IEnumerable<Item>>(() => Children.OfType<Item>().ToArray());
+            _robotComponents = new Lazy<IEnumerable<RobotComponent>>(() => Components.OfType<RobotComponent>().ToArray());
+        }
 
         protected virtual void OnLockError(Lock @lock, ErrorCodes error)
         {
@@ -251,7 +265,7 @@ namespace Perpetuum.Robots
             {
                 module.Unequip(targetContainer);
             }
-            InitModules();
+
             if (!withContainer)
                 return;
 
@@ -325,14 +339,6 @@ namespace Perpetuum.Robots
             return RobotComponents.FirstOrDefault(c => c.Type == componentType);
         }
 
-        private Lazy<IEnumerable<Module>> _modules;
-        private Lazy<IEnumerable<ActiveModule>> _activeModules;
-        private void InitModules()
-        {
-            _modules = new Lazy<IEnumerable<Module>>(() => RobotComponents.SelectMany(c => c.Modules).ToArray());
-            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Modules.OfType<ActiveModule>().ToArray());
-        }
-
         public IEnumerable<Module> Modules
         {
             get { return _modules.Value; }
@@ -341,15 +347,6 @@ namespace Perpetuum.Robots
         public IEnumerable<ActiveModule> ActiveModules
         {
             get { return _activeModules.Value; }
-        }
-
-        private Lazy<IEnumerable<Item>> _components;
-        private Lazy<IEnumerable<RobotComponent>> _robotComponents;
-        private void InitComponents()
-        {
-
-            _components = new Lazy<IEnumerable<Item>>(() => Children.OfType<Item>().ToArray());
-            _robotComponents = new Lazy<IEnumerable<RobotComponent>>(() => Components.OfType<RobotComponent>().ToArray());
         }
 
         public IEnumerable<Item> Components

--- a/src/Perpetuum/Robots/RobotComponent.cs
+++ b/src/Perpetuum/Robots/RobotComponent.cs
@@ -40,6 +40,13 @@ namespace Perpetuum.Robots
         {
             _type = type;
             _extensionReader = extensionReader;
+            InitModules();
+        }
+
+        public override void Initialize()
+        {
+            InitModules();
+            base.Initialize();
         }
 
         public override void AcceptVisitor(IEntityVisitor visitor)
@@ -74,14 +81,22 @@ namespace Perpetuum.Robots
             get { return _type.ToString().ToLower(); }
         }
 
+        private Lazy<IEnumerable<Module>> _modules;
+        private Lazy<IEnumerable<ActiveModule>> _activeModules;
+        private void InitModules()
+        {
+            _modules = new Lazy<IEnumerable<Module>>(() => Children.OfType<Module>().ToArray());
+            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Children.OfType<ActiveModule>().ToArray());
+        }
+
         public IEnumerable<Module> Modules
         {
-            get { return Children.OfType<Module>(); }
+            get { return _modules.Value; }
         }
 
         public IEnumerable<ActiveModule> ActiveModules
         {
-            get { return Modules.OfType<ActiveModule>(); }
+            get { return _activeModules.Value; }
         }
 
         public void Update(TimeSpan time)
@@ -122,6 +137,7 @@ namespace Perpetuum.Robots
         {
             var module = GetModule(slot);
             module?.Unequip(targetContainer);
+            InitModules();
         }
 
         public bool CheckUniqueModule(Module module)
@@ -185,6 +201,7 @@ namespace Perpetuum.Robots
 
             AddChild(module);
             module.Slot = slot;
+            InitModules();
         }
 
         private ErrorCodes CanChangeModule(int sourceSlot, int targetSlot)
@@ -216,6 +233,7 @@ namespace Perpetuum.Robots
 
             if (targetModule != null)
                 targetModule.Slot = sourceSlot;
+            InitModules();
         }
 
         public override Dictionary<string, object> ToDictionary()

--- a/src/Perpetuum/Robots/RobotComponent.cs
+++ b/src/Perpetuum/Robots/RobotComponent.cs
@@ -136,7 +136,6 @@ namespace Perpetuum.Robots
         {
             var module = GetModule(slot);
             module?.Unequip(targetContainer);
-            InitModules();
         }
 
         public bool CheckUniqueModule(Module module)

--- a/src/Perpetuum/Robots/RobotComponent.cs
+++ b/src/Perpetuum/Robots/RobotComponent.cs
@@ -40,13 +40,20 @@ namespace Perpetuum.Robots
         {
             _type = type;
             _extensionReader = extensionReader;
-            InitModules();
         }
 
         public override void Initialize()
         {
             InitModules();
             base.Initialize();
+        }
+
+        private Lazy<IEnumerable<Module>> _modules;
+        private Lazy<IEnumerable<ActiveModule>> _activeModules;
+        private void InitModules()
+        {
+            _modules = new Lazy<IEnumerable<Module>>(() => Children.OfType<Module>().ToArray());
+            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Children.OfType<ActiveModule>().ToArray());
         }
 
         public override void AcceptVisitor(IEntityVisitor visitor)
@@ -79,14 +86,6 @@ namespace Perpetuum.Robots
         public string ComponentName
         {
             get { return _type.ToString().ToLower(); }
-        }
-
-        private Lazy<IEnumerable<Module>> _modules;
-        private Lazy<IEnumerable<ActiveModule>> _activeModules;
-        private void InitModules()
-        {
-            _modules = new Lazy<IEnumerable<Module>>(() => Children.OfType<Module>().ToArray());
-            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Children.OfType<ActiveModule>().ToArray());
         }
 
         public IEnumerable<Module> Modules
@@ -201,7 +200,6 @@ namespace Perpetuum.Robots
 
             AddChild(module);
             module.Slot = slot;
-            InitModules();
         }
 
         private ErrorCodes CanChangeModule(int sourceSlot, int targetSlot)
@@ -233,7 +231,6 @@ namespace Perpetuum.Robots
 
             if (targetModule != null)
                 targetModule.Slot = sourceSlot;
-            InitModules();
         }
 
         public override Dictionary<string, object> ToDictionary()


### PR DESCRIPTION
Because every update loop updates every robot, which updates every module on every robotcomponent, the accessor the the underlying collection of modules and components is actually impactful.

Looping with IEnumerable is nice to defer the underlying query it may be built on.  But if this is mostly static (for 99.999% of all update calls) then it would be wise to compute this and store it in an array.

The risk is that if the underlying collection (entity children) are manipulated not using the correct interface/public methods then the lazy-initializer (as the resetting mechanism to the collection) might become inconsistent.  But this is why we have reviews and testing right? :)