### PR TITLE
Prevent seeded CT combination

### DIFF
--- a/src/Perpetuum/Services/ProductionEngine/PBSFacilities.cs
+++ b/src/Perpetuum/Services/ProductionEngine/PBSFacilities.cs
@@ -674,6 +674,9 @@ namespace Perpetuum.Services.ProductionEngine
             sourceCalibration.ED.CategoryFlags.IsCategory(CategoryFlags.cf_random_calibration_programs).ThrowIfTrue(ErrorCodes.MissionItemCantBeForged);
             targetCalibration.ED.CategoryFlags.IsCategory(CategoryFlags.cf_random_calibration_programs).ThrowIfTrue(ErrorCodes.MissionItemCantBeForged);
 
+            //OPP: prevent combination of Shop-provided CTs - will inflate number of runs
+            sourceCalibration.ED.CategoryFlags.IsCategory(CategoryFlags.cf_dynamic_cprg).ThrowIfTrue(ErrorCodes.MissionItemCantBeForged);
+            targetCalibration.ED.CategoryFlags.IsCategory(CategoryFlags.cf_dynamic_cprg).ThrowIfTrue(ErrorCodes.MissionItemCantBeForged);
 
             sourceCalibration.CheckTargetForForgeAndThrowIfFailed(targetCalibration);
 


### PR DESCRIPTION
Closes: #261 

Because of the falloff curve of the CT combining facility, low point CTs will automatically merge to become many more times valuable and multiply the number of available runs, rather than simply provide an extra but diminishing few (as designed with normal CTs)

Until a more sophisticated approach can be made to scale this falloff curve to the source-CT's original target values, as provided from the item shop, and not exceed it with an asymptotic curve - prevent their combination for now.

Bonus task: [make a better errorcode and localize.](https://github.com/OpenPerpetuum/PerpetuumServer/issues/350)