### PR TITLE
Fix npc roamspawn

### DIFF
--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -1501,10 +1501,10 @@ namespace Perpetuum.Bootstrapper
             RegisterFlock<NormalFlock>(PresenceType.Dynamic);
             RegisterFlock<RemoteSpawningFlock>(PresenceType.DynamicExtended);
             RegisterFlock<Flock>(PresenceType.Random);
-            RegisterFlock<Flock>(PresenceType.Roaming);
-            RegisterFlock<NormalFlock>(PresenceType.FreeRoaming);
+            RegisterFlock<RoamingFlock>(PresenceType.Roaming);
+            RegisterFlock<RoamingFlock>(PresenceType.FreeRoaming);
             RegisterFlock<NormalFlock>(PresenceType.Interzone);
-            RegisterFlock<NormalFlock>(PresenceType.InterzoneRoaming);
+            RegisterFlock<RoamingFlock>(PresenceType.InterzoneRoaming);
 
             RegisterPresence<Presence>(PresenceType.Normal);
             RegisterPresence<DirectPresence>(PresenceType.Direct).OnActivated(e =>

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -713,6 +713,7 @@
     <Compile Include="Zones\NpcSystem\Flocks\IFlockConfiguration.cs" />
     <Compile Include="Zones\NpcSystem\Flocks\IFlockConfigurationRepository.cs" />
     <Compile Include="Zones\NpcSystem\Flocks\RemoteSpawningFlock.cs" />
+    <Compile Include="Zones\NpcSystem\Flocks\RoamingFlock.cs" />
     <Compile Include="Zones\NpcSystem\NpcBossInfo.cs" />
     <Compile Include="Zones\NpcSystem\NpcEp.cs" />
     <Compile Include="Zones\NpcSystem\Reinforcements\INpcReinforcementWave.cs" />

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/Flock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/Flock.cs
@@ -150,10 +150,6 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
 
         protected virtual Position GetSpawnPosition(Position spawnOrigin)
         {
-            if (Presence is IRoamingPresence presence)
-            {
-                spawnOrigin = presence.SpawnOrigin;
-            }
             var spawnRangeMin = Configuration.SpawnRange.Min;
             var spawnRangeMax = Configuration.SpawnRange.Max.Min(HomeRange);
 

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/NormalFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/NormalFlock.cs
@@ -13,8 +13,6 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
     {
         private readonly ConcurrentQueue<TimeTracker> _spawnTimes = new ConcurrentQueue<TimeTracker>();
 
-        private TimeSpan _elapsedTime = TimeSpan.Zero;
-
         public double respawnMultiplierLow;
         public double respawnMultiplier = 1.0;
 
@@ -82,22 +80,11 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
 
         public override void Update(TimeSpan time)
         {
-            _elapsedTime += time;
-
             if (!Presence.Configuration.IsRespawnAllowed) 
                 return;
 
-            if(Presence is IRoamingPresence roaming)
-            {
-                if(roaming.StackFSM.Current is SpawnState) // TODO probably not a great place to handle this conflict, but does resolve the initial issue
-                {
-                    //Probably best to have all roaming presences respawn using the SpawnState on its FSM
-                    Logger.DebugWarning($"Presence {Presence.Name} is still in a Spawning state! --- BLOCK all flock-level spawning");
-                    return;
-                }
-            }
-
             RespawnAllDeadNpcs(time);
+            base.Update(time);
         }
 
         private TimeTracker _nextSpawnTime;

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/NormalFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/NormalFlock.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Perpetuum.Log;
 using Perpetuum.Timers;
 using Perpetuum.Units;
 using Perpetuum.Zones.NpcSystem.Presences;
+using Perpetuum.Zones.NpcSystem.Presences.PathFinders;
 
 namespace Perpetuum.Zones.NpcSystem.Flocks
 {
@@ -84,6 +86,16 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
 
             if (!Presence.Configuration.IsRespawnAllowed) 
                 return;
+
+            if(Presence is IRoamingPresence roaming)
+            {
+                if(roaming.StackFSM.Current is SpawnState) // TODO probably not a great place to handle this conflict, but does resolve the initial issue
+                {
+                    //Probably best to have all roaming presences respawn using the SpawnState on its FSM
+                    Logger.DebugWarning($"Presence {Presence.Name} is still in a Spawning state! --- BLOCK all flock-level spawning");
+                    return;
+                }
+            }
 
             RespawnAllDeadNpcs(time);
         }

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/NormalFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/NormalFlock.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Perpetuum.Log;
 using Perpetuum.Timers;
 using Perpetuum.Units;
 using Perpetuum.Zones.NpcSystem.Presences;
-using Perpetuum.Zones.NpcSystem.Presences.PathFinders;
 
 namespace Perpetuum.Zones.NpcSystem.Flocks
 {
@@ -84,7 +82,6 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
                 return;
 
             RespawnAllDeadNpcs(time);
-            base.Update(time);
         }
 
         private TimeTracker _nextSpawnTime;

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/RemoteSpawningFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/RemoteSpawningFlock.cs
@@ -15,7 +15,7 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
         {
             if (Presence is DynamicPresenceExtended presence)
             {
-                return presence.SpawnLocation;
+                return presence.SpawnLocation.Clamp(Presence.Zone.Size);
             }
             return base.GetSpawnPosition(spawnOrigin);
         }

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/RoamingFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/RoamingFlock.cs
@@ -29,5 +29,14 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
             }
             return false;
         }
+
+        protected override Position GetSpawnPosition(Position spawnOrigin)
+        {
+            if (Presence is IRoamingPresence roaming)
+            {
+                return roaming.SpawnOrigin.Clamp(Presence.Zone.Size);
+            }
+            return base.GetSpawnPosition(spawnOrigin);
+        }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/RoamingFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/RoamingFlock.cs
@@ -1,0 +1,33 @@
+﻿using Perpetuum.Zones.NpcSystem.Presences;
+using Perpetuum.Zones.NpcSystem.Presences.PathFinders;
+using System;
+
+namespace Perpetuum.Zones.NpcSystem.Flocks
+{
+    /// <summary>
+    /// A NormalFlock that is the child of a RoamingPresence
+    /// NormalFlocks respawn members on the Update call
+    /// This class prevents that and allows the IRoamingPresence SpawnState to handle respawning all flocks.
+    /// </summary>
+    public class RoamingFlock : NormalFlock
+    {
+        public RoamingFlock(IFlockConfiguration configuration, Presence presence) : base(configuration, presence) { }
+
+        public override void Update(TimeSpan time)
+        {
+            if (IsPresenceInSpawningState())
+                return;
+
+            base.Update(time);
+        }
+
+        private bool IsPresenceInSpawningState()
+        {
+            if (Presence is IRoamingPresence roaming)
+            {
+                return roaming.StackFSM.Current is SpawnState;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/FreeRoamingPathFinder.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/FreeRoamingPathFinder.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Linq;
 using Perpetuum.Collections;
 using Perpetuum.ExportedTypes;
+using Perpetuum.Log;
 using Perpetuum.PathFinders;
 using Perpetuum.Zones.NpcSystem.Flocks;
 
@@ -24,11 +25,19 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
 
         public Point FindSpawnPosition(IRoamingPresence presence)
         {
-            var homeRange = presence.Flocks.Max(f => f.HomeRange);
-            var rangeMax = homeRange * 2;
+            try
+            {
+                var homeRange = presence.Flocks.Max(f => f.HomeRange).Clamp(10, 40);
+                var rangeMax = homeRange * 2;
 
-            var walkableArea = _zone.FindWalkableArea(presence.Area, rangeMax * rangeMax);
-            return walkableArea.RandomElement();
+                var walkableArea = _zone.FindWalkableArea(presence.Area, rangeMax * rangeMax);
+                return walkableArea.RandomElement();
+            }
+            catch (Exception e)
+            {
+                Logger.Exception(e);
+            }
+            return Point.Empty;
         }
 
         public Point FindNextRoamingPosition(IRoamingPresence presence)

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/FreeRoamingPathFinder.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/FreeRoamingPathFinder.cs
@@ -6,7 +6,6 @@ using System.Drawing;
 using System.Linq;
 using Perpetuum.Collections;
 using Perpetuum.ExportedTypes;
-using Perpetuum.Log;
 using Perpetuum.PathFinders;
 using Perpetuum.Zones.NpcSystem.Flocks;
 
@@ -25,19 +24,11 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
 
         public Point FindSpawnPosition(IRoamingPresence presence)
         {
-            try
-            {
-                var homeRange = presence.Flocks.Max(f => f.HomeRange).Clamp(10, 40);
-                var rangeMax = homeRange * 2;
+            var homeRange = presence.Flocks.Max(f => f.HomeRange).Clamp(10, 40);
+            var rangeMax = homeRange * 2;
 
-                var walkableArea = _zone.FindWalkableArea(presence.Area, rangeMax * rangeMax);
-                return walkableArea.RandomElement();
-            }
-            catch (Exception e)
-            {
-                Logger.Exception(e);
-            }
-            return Point.Empty;
+            var walkableArea = _zone.FindWalkableArea(presence.Area, rangeMax * rangeMax);
+            return walkableArea.RandomElement();
         }
 
         public Point FindNextRoamingPosition(IRoamingPresence presence)

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/RoamingStates.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/RoamingStates.cs
@@ -69,13 +69,14 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
         {
             Position spawnPosition;
             bool anyPlayersAround;
+            int range = 200;
 
             do
             {
                 spawnPosition = _presence.PathFinder.FindSpawnPosition(_presence).ToPosition();
-                anyPlayersAround = _presence.Zone.Players.WithinRange(spawnPosition, 200).Any();
-
-            } while (anyPlayersAround);
+                anyPlayersAround = _presence.Zone.Players.WithinRange(spawnPosition, range).Any();
+                range--;
+            } while (anyPlayersAround && range > 0);
 
             _presence.SpawnOrigin = spawnPosition;
             _presence.CurrentRoamingPosition = spawnPosition;


### PR DESCRIPTION
Closes: #351 
This one has haunted us for sometime.  It is possible via race condition that the randomroamers (because they used `NormalFlock`) could attempt to spawn flock members while the presence state-machine was attempting to resolve a respawn location.
At best this was wiping the spawnOrigin, at worst it results in double spawns (check-set race).

The fix is to allow both behaviors, but only one at a time!
The NormalFlock update loop checks if it is time to respawn dead members.  But if the whole presence is wiped, the RoamingPresence FSM will go into a SpawnState which resolves a location to spawn and respawns the whole presence.

So now the behavior will be:
 - flock members will respawn based on their respawn times if the presence is non-empty (aka, flock members still actively roaming) and the respawn members will simply join them at their current home position.
 - if all flock members are dead, the presence will find a new place to spawn all members in at - based on the roaming respawn logic.