### PR TITLE
More routes where robot was uninitialized

### DIFF
--- a/src/Perpetuum/Robots/Robot.cs
+++ b/src/Perpetuum/Robots/Robot.cs
@@ -71,24 +71,19 @@ namespace Perpetuum.Robots
         public override void Initialize()
         {
             InitComponents();
-            InitModules();
             base.Initialize();
         }
 
         private Lazy<IEnumerable<Module>> _modules;
         private Lazy<IEnumerable<ActiveModule>> _activeModules;
-        private void InitModules()
-        {
-            _modules = new Lazy<IEnumerable<Module>>(() => RobotComponents.SelectMany(c => c.Modules).ToArray());
-            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Modules.OfType<ActiveModule>().ToArray());
-        }
-
         private Lazy<IEnumerable<Item>> _components;
         private Lazy<IEnumerable<RobotComponent>> _robotComponents;
         private void InitComponents()
         {
             _components = new Lazy<IEnumerable<Item>>(() => Children.OfType<Item>().ToArray());
             _robotComponents = new Lazy<IEnumerable<RobotComponent>>(() => Components.OfType<RobotComponent>().ToArray());
+            _modules = new Lazy<IEnumerable<Module>>(() => RobotComponents.SelectMany(c => c.Modules).ToArray());
+            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Modules.OfType<ActiveModule>().ToArray());
         }
 
         protected virtual void OnLockError(Lock @lock, ErrorCodes error)

--- a/src/Perpetuum/Robots/RobotComponent.cs
+++ b/src/Perpetuum/Robots/RobotComponent.cs
@@ -53,7 +53,7 @@ namespace Perpetuum.Robots
         private void InitModules()
         {
             _modules = new Lazy<IEnumerable<Module>>(() => Children.OfType<Module>().ToArray());
-            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Children.OfType<ActiveModule>().ToArray());
+            _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Modules.OfType<ActiveModule>().ToArray());
         }
 
         public override void AcceptVisitor(IEntityVisitor visitor)

--- a/src/Perpetuum/Robots/RobotHelper.cs
+++ b/src/Perpetuum/Robots/RobotHelper.cs
@@ -47,12 +47,16 @@ namespace Perpetuum.Robots
 
         public Robot LoadRobot(long robotEid)
         {
-            return (Robot) _unitHelper.LoadUnit(robotEid);
+            var robot = (Robot) _unitHelper.LoadUnit(robotEid);
+            robot?.Initialize();
+            return robot;
         }
 
         public Robot LoadRobotOrThrow(long robotEid)
         {
-            return (Robot) _unitHelper.LoadUnitOrThrow(robotEid);
+            var robot = (Robot) _unitHelper.LoadUnitOrThrow(robotEid);
+            robot.Initialize();
+            return robot;
         }
 
         public bool IsSelected(Robot robot)


### PR DESCRIPTION
Request handlers load a bare robot object for the purposes of manipulating its entity-tree.
So the underlying collections to access the children need to be initialized.