### PR TITLE
Groundtype autopopulate

### DIFF
--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -2773,6 +2773,7 @@ namespace Perpetuum.Bootstrapper
             RegisterZoneRequestHandler<ZoneDrawBlockingByDefinition>(Commands.ZoneDrawBlockingByDefinition);
             RegisterZoneRequestHandler<ZoneCleanBlockingByDefinition>(Commands.ZoneCleanBlockingByDefinition);
             RegisterZoneRequestHandler<ZoneCleanObstacleBlocking>(Commands.ZoneCleanObstacleBlocking);
+            RegisterZoneRequestHandler<ZoneFillGroundTypeRandom>(Commands.ZoneFillGroundTypeRandom);
 
 
 

--- a/src/Perpetuum.RequestHandlers/Perpetuum.RequestHandlers.csproj
+++ b/src/Perpetuum.RequestHandlers/Perpetuum.RequestHandlers.csproj
@@ -624,6 +624,7 @@
     <Compile Include="Zone\ZoneSetPlantsMode.cs" />
     <Compile Include="Zone\ZoneSetPlantSpeed.cs" />
     <Compile Include="Zone\ZoneSetQueueLength.cs" />
+    <Compile Include="Zone\ZoneFillGroundTypeRandom.cs" />
     <Compile Include="Zone\ZoneSetReinforceCounter.cs" />
     <Compile Include="Zone\ZoneSetRuntimeZoneEntityName.cs" />
     <Compile Include="Zone\ZoneSwitchDegrade.cs" />

--- a/src/Perpetuum.RequestHandlers/Zone/ZoneFillGroundTypeRandom.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/ZoneFillGroundTypeRandom.cs
@@ -1,0 +1,71 @@
+﻿using Perpetuum.Host.Requests;
+using Perpetuum.Log;
+using Perpetuum.Zones.Terrains;
+using Perpetuum.Zones.Terrains.Materials.Plants;
+using System;
+using System.Linq;
+
+namespace Perpetuum.RequestHandlers.Zone
+{
+    public class ZoneFillGroundTypeRandom : IRequestHandler<IZoneRequest>
+    {
+        private bool IsGroundTypeFilled(ILayer<PlantInfo> plants)
+        {
+            return !plants.RawData.Any(p => p.groundType == GroundType.undefined);
+        }
+
+        private void SetGroundTypeWithCircle(ILayer<PlantInfo> plants, Position center, int radius, GroundType groundType)
+        {
+            var x0 = (center.intX - radius).Clamp(0, plants.Width - 1);
+            var x1 = (center.intX + radius).Clamp(0, plants.Width);
+            var y0 = (center.intY - radius).Clamp(0, plants.Width - 1);
+            var y1 = (center.intY + radius).Clamp(0, plants.Width);
+            var period = FastRandom.NextInt(3, 32);
+            var fuzzPercent = FastRandom.NextDouble(0.05, 0.5);
+            var noiseMagnitude = FastRandom.NextInt(1, (int)(radius * 0.25));
+            for (int x = x0; x < x1; x++)
+            {
+                for (int y = y0; y < y1; y++)
+                {
+                    var p = new Position(x, y);
+                    var angle = center.DirectionTo(p) * Math.PI;
+                    var sin = (Math.Sin(angle * period) + 1.0) * 0.5;
+                    var noise = (FastRandom.NextDouble()-0.5)* noiseMagnitude;
+                    var boundary = radius * (1.0 - fuzzPercent) + (radius * sin * fuzzPercent);
+                    if (center.TotalDistance2D(x, y) > (boundary + noise).Clamp(1, radius)) continue;
+                    var info = plants.GetValue(x, y);
+                    info.SetGroundType(groundType);
+                    plants[x, y] = info;
+                }
+            }
+        }
+
+        private GroundType PickRandom()
+        {
+            var values = ((GroundType[])Enum.GetValues(typeof(GroundType))).Where(g => g != GroundType.undefined).ToArray();
+            return values[FastRandom.NextInt(values.Length - 1)];
+        }
+
+        public void HandleRequest(IZoneRequest request)
+        {
+            request.Zone.IsLayerEditLocked.ThrowIfTrue(ErrorCodes.TileTerraformProtected);
+            var minRadius = request.Data.GetOrDefault<int>(k.size).Clamp(2, 200);
+            var iterations = request.Data.GetOrDefault<int>(k.numberOfRuns).Clamp(1, 1000);
+            var zoneRect = request.Zone.Size;
+            var plants = request.Zone.Terrain.Plants;
+            Logger.Info($"{request.Zone.Id} filling groundtype with {iterations} and brush radius {minRadius}");
+            for (var i = 0; i < iterations; i++)
+            {
+                if (i % 100 == 0)
+                {
+                    Logger.Info($"{request.Zone.Id} filling groundtype iteration {i}/{iterations}...");
+                }
+                var pos = zoneRect.GetRandomPosition(1);
+                var radius = (int)(FastRandom.NextDouble() * (minRadius * 0.5) + minRadius);
+                SetGroundTypeWithCircle(plants, pos, radius, PickRandom());
+            }
+            Logger.Info($"{request.Zone.Id} groundtype filled? {IsGroundTypeFilled(plants)}");
+            Message.Builder.FromRequest(request).WithOk().Send();
+        }
+    }
+}

--- a/src/Perpetuum/Commands.cs
+++ b/src/Perpetuum/Commands.cs
@@ -1302,6 +1302,17 @@ namespace Perpetuum
             }
         };
 
+        public static readonly Command ZoneFillGroundTypeRandom = new Command
+        {
+            Text = "zoneFillGroundTypeRandom",
+            AccessLevel = AccessLevel.admin,
+            Arguments =
+            {
+                new Argument<int>(k.size),
+                new Argument<int>(k.numberOfRuns)
+            }
+        };
+
         public static readonly Command ZoneSetBaseDetails = new Command
         {
             Text = "zoneSetBaseDetails",

--- a/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandHandlers.cs
+++ b/src/Perpetuum/Services/Channels/ChatCommands/AdminCommandHandlers.cs
@@ -917,7 +917,7 @@ namespace Perpetuum.Services.Channels.ChatCommands
                     { "layerName", data.Command.Args[0] }
                 };
 
-            string cmd = string.Format("zoneClearLayer:zone_{0}:{1}", data.Sender.ZoneId, GenxyConverter.Serialize(dictionary));
+            string cmd = string.Format("{0}:zone_{1}:{2}", Commands.ZoneClearLayer.Text, data.Sender.ZoneId, GenxyConverter.Serialize(dictionary));
             HandleLocalRequest(data, cmd);
         }
         [ChatCommand("ZoneSetPlantSpeed")]
@@ -1223,6 +1223,47 @@ namespace Perpetuum.Services.Channels.ChatCommands
             CheckZoneId(data, zoneId);
             var dictionary = new Dictionary<string, object>() { { k.layerName, k.groundType } };
             var cmd = string.Format("{0}:zone_{1}:{2}", Commands.ZoneClearLayer.Text, zoneId, GenxyConverter.Serialize(dictionary));
+            SendMessageToAll(data, $"Sending: {cmd}");
+            HandleLocalRequest(data, cmd);
+            SendMessageToAll(data, $"Command completed");
+        }
+        [ChatCommand("ZoneRandomFillGroundType")]
+        public static void ZoneRandomFillGroundType(AdminCommandData data)
+        {
+            if (!IsDevModeEnabled(data))
+                return;
+
+            int radius = 200;
+            int iterations = 10;
+            int zoneId = data.Sender.ZoneId ?? -1;
+            if (data.Command.Args.Length > 0)
+            {
+                if (!int.TryParse(data.Command.Args[0], out radius))
+                {
+                    throw PerpetuumException.Create(ErrorCodes.RequiredArgumentIsNotSpecified);
+                }
+                if (data.Command.Args.Length > 1)
+                {
+                    if (!int.TryParse(data.Command.Args[1], out iterations))
+                    {
+                        throw PerpetuumException.Create(ErrorCodes.RequiredArgumentIsNotSpecified);
+                    }
+                    if (data.Command.Args.Length > 2)
+                    {
+                        if (!int.TryParse(data.Command.Args[2], out zoneId))
+                        {
+                            throw PerpetuumException.Create(ErrorCodes.RequiredArgumentIsNotSpecified);
+                        }
+                    }
+                }
+            }
+
+            CheckZoneId(data, zoneId);
+            var dictionary = new Dictionary<string, object>(){
+                    { k.size, radius },
+                    { k.numberOfRuns, iterations }
+                };
+            var cmd = string.Format("{0}:zone_{1}:{2}", Commands.ZoneFillGroundTypeRandom.Text, zoneId, GenxyConverter.Serialize(dictionary));
             SendMessageToAll(data, $"Sending: {cmd}");
             HandleLocalRequest(data, cmd);
             SendMessageToAll(data, $"Command completed");

--- a/src/Perpetuum/Zones/Terrains/Materials/Plants/PlantInfo.cs
+++ b/src/Perpetuum/Zones/Terrains/Materials/Plants/PlantInfo.cs
@@ -25,7 +25,12 @@ namespace Perpetuum.Zones.Terrains.Materials.Plants
 
         public void ClearGroundType()
         {
-            groundType = GroundType.undefined;
+            SetGroundType(GroundType.undefined);
+        }
+
+        public void SetGroundType(GroundType type)
+        {
+            groundType = type;
         }
 
         public void SetPlant(byte newState, PlantType newPlantType)


### PR DESCRIPTION
Closes: #359 but not an optimal solution, just a command to let user throw circles down on the zone a configured number of times.

Just to save time and avoid those edge-painting client crashes