### PR TITLE
Ore npc fix

### DIFF
--- a/src/Perpetuum/Zones/NpcSystem/Flocks/Flock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/Flock.cs
@@ -137,7 +137,7 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
 
             npc.LootGenerator = gen;
             npc.HomeRange = HomeRange;
-            npc.HomePosition = spawnPosition;
+            npc.HomePosition = GetHomePosition(spawnPosition);
             npc.CallForHelp = Configuration.IsCallForHelp;
 
             OnNpcCreated(npc);
@@ -155,6 +155,11 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
 
             var spawnPosition = spawnOrigin.GetRandomPositionInRange2D(spawnRangeMin, spawnRangeMax).Clamp(Presence.Zone.Size);
             return spawnPosition;
+        }
+
+        protected virtual Position GetHomePosition(Position spawnOrigin)
+        {
+            return spawnOrigin;
         }
 
         public event Action<Npc> NpcCreated;

--- a/src/Perpetuum/Zones/NpcSystem/Flocks/RemoteSpawningFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Flocks/RemoteSpawningFlock.cs
@@ -19,5 +19,14 @@ namespace Perpetuum.Zones.NpcSystem.Flocks
             }
             return base.GetSpawnPosition(spawnOrigin);
         }
+
+        protected override Position GetHomePosition(Position spawnOrigin)
+        {
+            if (Presence is DynamicPresenceExtended presence)
+            {
+                return presence.DynamicPosition.Clamp(Presence.Zone.Size);
+            }
+            return base.GetSpawnPosition(spawnOrigin);
+        }
     }
 }


### PR DESCRIPTION
Roaming fix made spawn location generation a lot more straightforward, but the DynamicPresence logic was dependent on the initialization order to create separate spawn and home locations.

Closes: #376 

TL;DR previous fix requires more fixes, and is fixed