### PR TITLE
Npc infestation: growing spawns of npcs

### DIFF
--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -184,6 +184,7 @@ using UnpackItems = Perpetuum.RequestHandlers.UnpackItems;
 using UnstackAmount = Perpetuum.RequestHandlers.UnstackAmount;
 using Perpetuum.Services.Strongholds;
 using Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence;
+using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
 
 namespace Perpetuum.Bootstrapper
 {
@@ -1458,6 +1459,13 @@ namespace Perpetuum.Bootstrapper
             _builder.RegisterType<RandomFlockSelector>().As<IRandomFlockSelector>();
 
             _builder.RegisterType<RandomFlockReader>()
+                .As<IRandomFlockReader>()
+                .SingleInstance()
+                .OnActivated(e => e.Instance.Init());
+
+            _builder.RegisterType<EscalatingPresenceFlockSelector>().As<IEscalatingPresenceFlockSelector>();
+
+            _builder.RegisterType<EscalatingFlocksReader>()
                 .As<IRandomFlockReader>()
                 .SingleInstance()
                 .OnActivated(e => e.Instance.Init());

--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -1466,7 +1466,7 @@ namespace Perpetuum.Bootstrapper
             _builder.RegisterType<EscalatingPresenceFlockSelector>().As<IEscalatingPresenceFlockSelector>();
 
             _builder.RegisterType<EscalatingFlocksReader>()
-                .As<IRandomFlockReader>()
+                .As<IEscalatingFlocksReader>()
                 .SingleInstance()
                 .OnActivated(e => e.Instance.Init());
 
@@ -1515,6 +1515,7 @@ namespace Perpetuum.Bootstrapper
             RegisterFlock<RoamingFlock>(PresenceType.FreeRoaming);
             RegisterFlock<NormalFlock>(PresenceType.Interzone);
             RegisterFlock<RoamingFlock>(PresenceType.InterzoneRoaming);
+            RegisterFlock<StaticExpiringFlock>(PresenceType.EscalatingRandomPresence);
 
             RegisterPresence<Presence>(PresenceType.Normal);
             RegisterPresence<DirectPresence>(PresenceType.Direct).OnActivated(e =>
@@ -1530,6 +1531,7 @@ namespace Perpetuum.Bootstrapper
             RegisterPresence<RoamingPresence>(PresenceType.FreeRoaming);
             RegisterPresence<InterzonePresence>(PresenceType.Interzone);
             RegisterPresence<InterzoneRoamingPresence>(PresenceType.InterzoneRoaming);
+            RegisterPresence<GrowingPresence>(PresenceType.EscalatingRandomPresence);
 
             _builder.Register<PresenceFactory>(x =>
             {

--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -185,6 +185,7 @@ using UnstackAmount = Perpetuum.RequestHandlers.UnstackAmount;
 using Perpetuum.Services.Strongholds;
 using Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence;
 using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
+using Perpetuum.Zones.NpcSystem.Presences.GrowingPresences;
 
 namespace Perpetuum.Bootstrapper
 {

--- a/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
+++ b/src/Perpetuum.Bootstrapper/PerpetuumBootstrapper.cs
@@ -1464,7 +1464,7 @@ namespace Perpetuum.Bootstrapper
                 .SingleInstance()
                 .OnActivated(e => e.Instance.Init());
 
-            _builder.RegisterType<EscalatingPresenceFlockSelector>().As<IEscalatingPresenceFlockSelector>();
+            _builder.RegisterType<EscalatingPresenceFlockSelector>().As<IEscalatingPresenceFlockSelector>().SingleInstance();
 
             _builder.RegisterType<EscalatingFlocksReader>()
                 .As<IEscalatingFlocksReader>()
@@ -1517,6 +1517,7 @@ namespace Perpetuum.Bootstrapper
             RegisterFlock<NormalFlock>(PresenceType.Interzone);
             RegisterFlock<RoamingFlock>(PresenceType.InterzoneRoaming);
             RegisterFlock<StaticExpiringFlock>(PresenceType.EscalatingRandomPresence);
+            RegisterFlock<StaticExpiringFlock>(PresenceType.GrowingNPCBasePresence);
 
             RegisterPresence<Presence>(PresenceType.Normal);
             RegisterPresence<DirectPresence>(PresenceType.Direct).OnActivated(e =>
@@ -1533,6 +1534,7 @@ namespace Perpetuum.Bootstrapper
             RegisterPresence<InterzonePresence>(PresenceType.Interzone);
             RegisterPresence<InterzoneRoamingPresence>(PresenceType.InterzoneRoaming);
             RegisterPresence<GrowingPresence>(PresenceType.EscalatingRandomPresence);
+            RegisterPresence<GrowingNPCBasePresence>(PresenceType.GrowingNPCBasePresence);
 
             _builder.Register<PresenceFactory>(x =>
             {

--- a/src/Perpetuum/ErrorCodes.cs
+++ b/src/Perpetuum/ErrorCodes.cs
@@ -704,6 +704,7 @@ namespace Perpetuum
         AccountAlreadyExists,
         RobotWrongType, // 666
         PBSTechLevelTooHighForZone,
-        TooCloseToOtherDevice
+        TooCloseToOtherDevice,
+        TooCloseToNPCBase,
     }
 }

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -716,6 +716,7 @@
     <Compile Include="Zones\NpcSystem\Flocks\RoamingFlock.cs" />
     <Compile Include="Zones\NpcSystem\NpcBossInfo.cs" />
     <Compile Include="Zones\NpcSystem\NpcEp.cs" />
+    <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\FlockEscalationSelector.cs" />
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\StaticExpiringFlock.cs" />
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\RandomSpawningExpiringPresence.cs" />
     <Compile Include="Zones\NpcSystem\Reinforcements\INpcReinforcementWave.cs" />

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -721,6 +721,7 @@
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\StaticExpiringFlock.cs" />
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\RandomSpawningExpiringPresence.cs" />
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\StaticSpawnState.cs" />
+    <Compile Include="Zones\NpcSystem\Presences\GrowingPresences\GrowingNPCBasePresence.cs" />
     <Compile Include="Zones\NpcSystem\Presences\GrowingPresences\GrowingPresence.cs" />
     <Compile Include="Zones\NpcSystem\Presences\GrowingPresences\GrowthStates.cs" />
     <Compile Include="Zones\NpcSystem\Reinforcements\INpcReinforcementWave.cs" />

--- a/src/Perpetuum/Perpetuum.csproj
+++ b/src/Perpetuum/Perpetuum.csproj
@@ -717,8 +717,12 @@
     <Compile Include="Zones\NpcSystem\NpcBossInfo.cs" />
     <Compile Include="Zones\NpcSystem\NpcEp.cs" />
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\FlockEscalationSelector.cs" />
+    <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\IRandomStaticPresence.cs" />
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\StaticExpiringFlock.cs" />
     <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\RandomSpawningExpiringPresence.cs" />
+    <Compile Include="Zones\NpcSystem\Presences\ExpiringStaticPresence\StaticSpawnState.cs" />
+    <Compile Include="Zones\NpcSystem\Presences\GrowingPresences\GrowingPresence.cs" />
+    <Compile Include="Zones\NpcSystem\Presences\GrowingPresences\GrowthStates.cs" />
     <Compile Include="Zones\NpcSystem\Reinforcements\INpcReinforcementWave.cs" />
     <Compile Include="Zones\NpcSystem\Reinforcements\INpcReinforcementsRepository.cs" />
     <Compile Include="Zones\NpcSystem\Reinforcements\INpcReinforcements.cs" />

--- a/src/Perpetuum/Zones/DistanceConstants.cs
+++ b/src/Perpetuum/Zones/DistanceConstants.cs
@@ -48,7 +48,7 @@ namespace Perpetuum.Zones
         public const double MISSION_RANDOM_POINT_FINDRADIUS_DEFAULT = 100;
 
         public const double MAX_NPC_FLOCK_HOME_RANGE = 40;
-
+        public const double PBS_DIST_FROM_NPC_BASE = 300;
         public const double GAMMA_BOMB_STACK_DISTANCE = 5.0;
 
         public static Dictionary<string, object> GetEnumDictionary()

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/FlockEscalationSelector.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/FlockEscalationSelector.cs
@@ -1,0 +1,76 @@
+﻿using Perpetuum.Data;
+using Perpetuum.Zones.NpcSystem.Flocks;
+using Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
+{
+
+    public interface IEscalatingPresenceFlockSelector
+    {
+        IFlockConfiguration[] GetFlocksForPresenceLevel(GrowingPresence presence, int level);
+    }
+    public class EscalatingPresenceFlockSelector : IEscalatingPresenceFlockSelector
+    {
+        private readonly EscalatingFlocksReader _reader;
+        public EscalatingPresenceFlockSelector(EscalatingFlocksReader reader)
+        {
+            _reader = reader;
+        }
+        public IFlockConfiguration[] GetFlocksForPresenceLevel(GrowingPresence presence, int level)
+        {
+            if (level < 0 || level > presence.GrowthLevel)
+            {
+                return new IFlockConfiguration[] { };
+            }
+            var infos = _reader.GetByPresence(presence);
+            var flocks = new List<IFlockConfiguration>();
+            foreach(var info in infos)
+            {
+                if(info.Chance >= FastRandom.NextDouble())
+                {
+                    flocks.Add(presence.FlockConfigurationRepository.Get(info.FlockId));
+                }
+            }
+            return flocks.ToArray();
+        }
+    }
+
+    public class EscalationInfo
+    {
+        public int FlockId { get; set; }
+        public int Level { get; set; }
+        public double Chance { get; set; }
+    }
+
+
+    public class EscalatingFlocksReader
+    {
+        private ILookup<int, EscalationInfo> _flockInfos;
+
+        public void Init()
+        {
+            _flockInfos = Db.Query().CommandText("select * from npcescalations")
+                .Execute()
+                .Select(r =>
+                {
+                    return new
+                    {
+                        presenceID = r.GetValue<int>("presenceid"),
+                        info = new EscalationInfo
+                        {
+                            FlockId = r.GetValue<int>("flockid"),
+                            Level = r.GetValue<int>("level"),
+                            Chance = r.GetValue<double>("chance")
+                        }
+                    };
+                }).ToLookup(x => x.presenceID, x => x.info);
+        }
+
+        public EscalationInfo[] GetByPresence(Presence presence)
+        {
+            return _flockInfos.GetOrEmpty(presence.Configuration.ID);
+        }
+    }
+}

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/FlockEscalationSelector.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/FlockEscalationSelector.cs
@@ -1,6 +1,5 @@
 ﻿using Perpetuum.Data;
 using Perpetuum.Zones.NpcSystem.Flocks;
-using Perpetuum.Zones.NpcSystem.Presences.GrowingPresences;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,29 +8,37 @@ namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
 {
     public interface IEscalatingPresenceFlockSelector
     {
-        IFlockConfiguration[] GetFlocksForPresenceLevel(GrowingPresence presence, int level);
+        IFlockConfiguration[] GetFlocksForPresenceLevel(int presenceId, int level);
+        int GetMaxLevelForPresence(int presenceId);
     }
     public class EscalatingPresenceFlockSelector : IEscalatingPresenceFlockSelector
     {
+        private readonly IFlockConfigurationRepository _flockConfigurationRepository;
         private readonly IEscalatingFlocksReader _reader;
         private readonly Random _random;
-        public EscalatingPresenceFlockSelector(IEscalatingFlocksReader reader)
+        public EscalatingPresenceFlockSelector(IEscalatingFlocksReader reader, IFlockConfigurationRepository flockConfigurationRepository)
         {
+            _flockConfigurationRepository = flockConfigurationRepository;
             _reader = reader;
             _random = new Random();
         }
-        public IFlockConfiguration[] GetFlocksForPresenceLevel(GrowingPresence presence, int level)
+        public IFlockConfiguration[] GetFlocksForPresenceLevel(int presenceId, int level)
         {
-            var infos = _reader.GetByPresence(presence).Where(info => info.Level == level);
+            var infos = _reader.GetByPresence(presenceId).Where(info => info.Level == level);
             var flocks = new List<IFlockConfiguration>();
             foreach (var info in infos)
             {
                 if (info.Chance >= _random.NextDouble())
                 {
-                    flocks.Add(presence.FlockConfigurationRepository.Get(info.FlockId));
+                    flocks.Add(_flockConfigurationRepository.Get(info.FlockId));
                 }
             }
             return flocks.ToArray();
+        }
+
+        public int GetMaxLevelForPresence(int presenceId)
+        {
+            return _reader.GetByPresence(presenceId).Select(info=>info.Level).DefaultIfEmpty(0).Max();
         }
     }
 
@@ -44,7 +51,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
 
     public interface IEscalatingFlocksReader
     {
-        EscalationInfo[] GetByPresence(Presence presence);
+        EscalationInfo[] GetByPresence(int presenceId);
     }
 
     public class EscalatingFlocksReader : IEscalatingFlocksReader
@@ -70,9 +77,9 @@ namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
                 }).ToLookup(x => x.presenceID, x => x.info);
         }
 
-        public EscalationInfo[] GetByPresence(Presence presence)
+        public EscalationInfo[] GetByPresence(int presenceId)
         {
-            return _flockInfos.GetOrEmpty(presence.Configuration.ID);
+            return _flockInfos.GetOrEmpty(presenceId);
         }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/FlockEscalationSelector.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/FlockEscalationSelector.cs
@@ -1,13 +1,12 @@
 ﻿using Perpetuum.Data;
 using Perpetuum.Zones.NpcSystem.Flocks;
-using Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence;
+using Perpetuum.Zones.NpcSystem.Presences.GrowingPresences;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
 {
-
     public interface IEscalatingPresenceFlockSelector
     {
         IFlockConfiguration[] GetFlocksForPresenceLevel(GrowingPresence presence, int level);
@@ -23,7 +22,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
         }
         public IFlockConfiguration[] GetFlocksForPresenceLevel(GrowingPresence presence, int level)
         {
-            var infos = _reader.GetByPresence(presence).Where(info=>info.Level==level);
+            var infos = _reader.GetByPresence(presence).Where(info => info.Level == level);
             var flocks = new List<IFlockConfiguration>();
             foreach (var info in infos)
             {

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/IRandomStaticPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/IRandomStaticPresence.cs
@@ -1,0 +1,4 @@
+﻿namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
+{
+    interface IRandomStaticPresence : IRoamingPresence { }
+}

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
@@ -7,6 +7,8 @@ using Perpetuum.ExportedTypes;
 using Perpetuum.Units.DockingBases;
 using Perpetuum.Units;
 using Perpetuum.Zones.Teleporting;
+using Perpetuum.Timers;
+using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
 
 namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
 {
@@ -15,7 +17,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
     /// </summary>
     public class RandomSpawningExpiringPresence : ExpiringPresence, IRoamingPresence
     {
-        public StackFSM StackFSM { get; }
+        public StackFSM StackFSM { get; protected set; }
         public Position SpawnOrigin { get; set; }
         public IRoamingPathFinder PathFinder { get; set; }
         public override Area Area => Configuration.Area;
@@ -51,6 +53,29 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
         }
     }
 
+    public class GrowingPresence : RandomSpawningExpiringPresence
+    {
+        public int GrowthLevel { get; protected set; }
+        public TimeSpan GrowTime { get; private set; }
+        public IEscalatingPresenceFlockSelector Selector { get; private set; }
+        public GrowingPresence(IZone zone, IPresenceConfiguration configuration, IEscalatingPresenceFlockSelector selector) : base(zone, configuration)
+        {
+            Selector = selector;
+            if (Configuration.GrowthSeconds != null)
+                GrowTime = TimeSpan.FromSeconds((int)Configuration.GrowthSeconds);
+
+            StackFSM = new StackFSM();
+            StackFSM.Push(new StaticSpawnState(this));
+        }
+
+        protected override void OnUpdate(TimeSpan time)
+        {
+            base.OnUpdate(time);
+            StackFSM.Update(time);
+        }
+
+    }
+
     public class StaticSpawnState : SpawnState
     {
         private readonly int BASE_RADIUS = 300;
@@ -76,6 +101,75 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
                 return true;
 
             return zone.Players.WithinRange2D(position, PLAYER_RADIUS).Any();
+        }
+    }
+
+    public class GrowSpawnState : StaticSpawnState
+    {
+        private readonly GrowingPresence _growingPresence;
+        public GrowSpawnState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist) {
+            _growingPresence = presence;
+        }
+
+        protected override void OnSpawned()
+        {
+            _presence.OnSpawned();
+            _presence.StackFSM.Push(new GrowthState(_growingPresence));
+        }
+    }
+
+    public class GrowthState : NullRoamingState
+    {
+        private readonly GrowingPresence _growingPresence;
+        private readonly TimeTracker _timer;
+        private int _currentLevel = 0;
+        public GrowthState(GrowingPresence presence) : base(presence) {
+            _growingPresence = presence;
+            _timer = new TimeTracker(_growingPresence.GrowTime);
+        }
+
+        public override void Update(TimeSpan time)
+        {
+            if (IsRunningTask)
+                return;
+
+            var members = GetAllMembers();
+            if (IsDeadAndExiting(members))
+                return;
+
+            if (!NextWaveReady(time))
+                return;
+
+            RunTask(() => SpawnNextWave(), t => { });
+        }
+
+        private bool NextWaveReady(TimeSpan time)
+        {
+            if(_currentLevel >= _growingPresence.GrowthLevel)
+                return false;
+
+            return CheckTimer(time);
+        }
+
+        private bool CheckTimer(TimeSpan time)
+        {
+            _timer.Update(time);
+            if (!_timer.Expired)
+                return false;
+
+            _timer.Reset();
+            return true;
+        }
+
+        private void SpawnNextWave()
+        {
+            var flockConfigs = _growingPresence.Selector.GetFlocksForPresenceLevel(_growingPresence, _currentLevel);
+            foreach(var config in flockConfigs)
+            {
+                var flock = _growingPresence.CreateAndAddFlock(config);
+                flock.SpawnAllMembers();
+            }
+            
         }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
@@ -49,7 +49,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
             base.OnPresenceExpired();
         }
 
-        public void OnSpawned()
+        public virtual void OnSpawned()
         {
             ResetDynamicDespawnTimer();
         }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
@@ -65,6 +65,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
     {
         public TimeSpan GrowTime { get; private set; }
         public IEscalatingPresenceFlockSelector Selector { get; private set; }
+        public int CurrentGrowthLevel { get; private set; }
         public GrowingPresence(IZone zone, IPresenceConfiguration configuration, IEscalatingPresenceFlockSelector selector) : base(zone, configuration)
         {
             Selector = selector;
@@ -74,23 +75,33 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
 
         protected override void InitStateMachine()
         {
+            CurrentGrowthLevel = FastRandom.NextInt(9);
             StackFSM = new StackFSM();
-            StackFSM.Push(new GrowSpawnState(this));
+            StackFSM.Push(new NPCBaseGrowState(this));
         }
 
         public override void LoadFlocks()
         {
-            var flockConfigs = Selector.GetFlocksForPresenceLevel(this, 0);
-            foreach (var config in flockConfigs)
+            for (var i = 0; i <= CurrentGrowthLevel; i++)
             {
-                CreateAndAddFlock(config);
+                var flockConfigs = Selector.GetFlocksForPresenceLevel(this, i);
+                foreach (var config in flockConfigs)
+                {
+                    CreateAndAddFlock(config);
+                }
             }
+        }
+
+        public void OnWaveSpawn(int level)
+        {
+            CurrentGrowthLevel = Math.Max(CurrentGrowthLevel, level);
         }
 
         protected override void OnPresenceExpired()
         {
             base.OnPresenceExpired();
             ClearFlocks();
+            CurrentGrowthLevel = 0;
             LoadFlocks();
         }
     }
@@ -140,20 +151,48 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
 
     public class NPCBaseGrowState : GrowSpawnState
     {
-        public NPCBaseGrowState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist) { }
+        private readonly GrowingPresence _growingPresence;
+        public NPCBaseGrowState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist)
+        {
+            _growingPresence = presence;
+        }
 
+        protected override void SetSpawnDelay()
+        {
+            if (_growingPresence.CurrentGrowthLevel == 0)
+            {
+                _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
+            }
+            _delay = TimeSpan.FromSeconds((int)_presence.Configuration.DynamicLifeTime * _repawnDelayModifier);
+            _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
+        }
 
         protected override bool IsValidSpawnPosition(Position position, int range)
         {
-            if(!_presence.Zone.Size.Contains(position.intX, position.intY))
+            var zone = _presence.Zone;
+            if (zone == null)
             {
                 return false;
             }
-            else if(_presence.Zone.Terrain.Controls.GetValue(position.intX, position.intY).IsAnyTerraformProtected)
+
+            var radiusToCheck = 4;
+            var centerPosition = position;
+            for (var j = centerPosition.intY - radiusToCheck; j < centerPosition.intY + radiusToCheck; j++)
             {
-                return false;
+                for (var i = centerPosition.intX - radiusToCheck; i < centerPosition.intX + radiusToCheck; i++)
+                {
+                    var cPos = new Position(i, j);
+                    if (!zone.Size.Contains(cPos.intX, cPos.intY))
+                        continue;
+
+                    var controlInfo = zone.Terrain.Controls.GetValue(position.intX, position.intY);
+                    if (controlInfo.IsAnyTerraformProtected || !zone.Terrain.Slope.CheckSlope(cPos.intX, cPos.intY, ZoneExtensions.MIN_SLOPE))
+                    {
+                        return false;
+                    }
+                }
             }
-            return IsInRange(position, range);
+            return !IsInRange(position, range);
         }
 
         protected override Position FindSpawnPosition()
@@ -171,6 +210,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
         {
             _growingPresence = presence;
             _timer = new TimeTracker(_growingPresence.GrowTime);
+            _currentLevel = _growingPresence.CurrentGrowthLevel;
         }
 
         public override void Update(TimeSpan time)
@@ -215,6 +255,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
                 var flock = _growingPresence.CreateAndAddFlock(config);
                 flock.SpawnAllMembers();
             }
+            _growingPresence.OnWaveSpawn(_currentLevel);
         }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
@@ -119,7 +119,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
             else if (zone.PresenceManager.GetPresences().OfType<RandomSpawningExpiringPresence>().Where(p => p.SpawnOrigin.IsInRangeOf2D(position, BASE_RADIUS)).Any())
                 return true;
 
-            return zone.Players.WithinRange2D(position, PLAYER_RADIUS).Any();
+            return zone.Players.WithinRange2D(position, range).Any();
         }
     }
 
@@ -135,6 +135,30 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
         {
             _presence.OnSpawned();
             _presence.StackFSM.Push(new GrowthState(_growingPresence));
+        }
+    }
+
+    public class NPCBaseGrowState : GrowSpawnState
+    {
+        public NPCBaseGrowState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist) { }
+
+
+        protected override bool IsValidSpawnPosition(Position position, int range)
+        {
+            if(!_presence.Zone.Size.Contains(position.intX, position.intY))
+            {
+                return false;
+            }
+            else if(_presence.Zone.Terrain.Controls.GetValue(position.intX, position.intY).IsAnyTerraformProtected)
+            {
+                return false;
+            }
+            return IsInRange(position, range);
+        }
+
+        protected override Position FindSpawnPosition()
+        {
+            return _presence.PathFinder.FindSpawnPosition(_presence).ToPosition();
         }
     }
 
@@ -166,7 +190,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
 
         private bool NextWaveReady(TimeSpan time)
         {
-            if(!CheckTimer(time))
+            if (!CheckTimer(time))
                 return false;
 
             _currentLevel++;

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/RandomSpawningExpiringPresence.cs
@@ -1,13 +1,7 @@
 ﻿using Perpetuum.StateMachines;
 using Perpetuum.Zones.NpcSystem.Presences.PathFinders;
 using System;
-using System.Linq;
 using System.Drawing;
-using Perpetuum.ExportedTypes;
-using Perpetuum.Units.DockingBases;
-using Perpetuum.Units;
-using Perpetuum.Zones.Teleporting;
-using Perpetuum.Timers;
 using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
 
 namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
@@ -15,7 +9,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
     /// <summary>
     /// A non-roaming ExpiringPresence that would spawning with Roaming rules
     /// </summary>
-    public class RandomSpawningExpiringPresence : ExpiringPresence, IRoamingPresence
+    public class RandomSpawningExpiringPresence : ExpiringPresence, IRandomStaticPresence, IRoamingPresence
     {
         public StackFSM StackFSM { get; protected set; }
         public Position SpawnOrigin { get; set; }
@@ -58,204 +52,6 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
         public void OnSpawned()
         {
             ResetDynamicDespawnTimer();
-        }
-    }
-
-    public class GrowingPresence : RandomSpawningExpiringPresence
-    {
-        public TimeSpan GrowTime { get; private set; }
-        public IEscalatingPresenceFlockSelector Selector { get; private set; }
-        public int CurrentGrowthLevel { get; private set; }
-        public GrowingPresence(IZone zone, IPresenceConfiguration configuration, IEscalatingPresenceFlockSelector selector) : base(zone, configuration)
-        {
-            Selector = selector;
-            if (Configuration.GrowthSeconds != null)
-                GrowTime = TimeSpan.FromSeconds((int)Configuration.GrowthSeconds);
-        }
-
-        protected override void InitStateMachine()
-        {
-            CurrentGrowthLevel = FastRandom.NextInt(9);
-            StackFSM = new StackFSM();
-            StackFSM.Push(new NPCBaseGrowState(this));
-        }
-
-        public override void LoadFlocks()
-        {
-            for (var i = 0; i <= CurrentGrowthLevel; i++)
-            {
-                var flockConfigs = Selector.GetFlocksForPresenceLevel(this, i);
-                foreach (var config in flockConfigs)
-                {
-                    CreateAndAddFlock(config);
-                }
-            }
-        }
-
-        public void OnWaveSpawn(int level)
-        {
-            CurrentGrowthLevel = Math.Max(CurrentGrowthLevel, level);
-        }
-
-        protected override void OnPresenceExpired()
-        {
-            base.OnPresenceExpired();
-            ClearFlocks();
-            CurrentGrowthLevel = 0;
-            LoadFlocks();
-        }
-    }
-
-    public class StaticSpawnState : SpawnState
-    {
-        private readonly int BASE_RADIUS = 300;
-        private readonly int PLAYER_RADIUS = 150;
-        public StaticSpawnState(IRoamingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist) { }
-
-        protected override void OnSpawned()
-        {
-            _presence.OnSpawned();
-            _presence.StackFSM.Push(new NullRoamingState(_presence));
-        }
-
-        protected override bool IsInRange(Position position, int range)
-        {
-            var zone = _presence.Zone;
-            if (zone.Configuration.IsGamma && zone.IsUnitWithCategoryInRange(CategoryFlags.cf_pbs_docking_base, position, BASE_RADIUS))
-                return true;
-            else if (zone.GetStaticUnits().OfType<DockingBase>().WithinRange2D(position, BASE_RADIUS).Any())
-                return true;
-            else if (zone.GetStaticUnits().OfType<Teleport>().WithinRange2D(position, PLAYER_RADIUS).Any())
-                return true;
-            else if (zone.PresenceManager.GetPresences().OfType<RandomSpawningExpiringPresence>().Where(p => p.SpawnOrigin.IsInRangeOf2D(position, BASE_RADIUS)).Any())
-                return true;
-
-            return zone.Players.WithinRange2D(position, range).Any();
-        }
-    }
-
-    public class GrowSpawnState : StaticSpawnState
-    {
-        private readonly GrowingPresence _growingPresence;
-        public GrowSpawnState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist)
-        {
-            _growingPresence = presence;
-        }
-
-        protected override void OnSpawned()
-        {
-            _presence.OnSpawned();
-            _presence.StackFSM.Push(new GrowthState(_growingPresence));
-        }
-    }
-
-    public class NPCBaseGrowState : GrowSpawnState
-    {
-        private readonly GrowingPresence _growingPresence;
-        public NPCBaseGrowState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist)
-        {
-            _growingPresence = presence;
-        }
-
-        protected override void SetSpawnDelay()
-        {
-            if (_growingPresence.CurrentGrowthLevel == 0)
-            {
-                _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
-            }
-            _delay = TimeSpan.FromSeconds((int)_presence.Configuration.DynamicLifeTime * _repawnDelayModifier);
-            _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
-        }
-
-        protected override bool IsValidSpawnPosition(Position position, int range)
-        {
-            var zone = _presence.Zone;
-            if (zone == null)
-            {
-                return false;
-            }
-
-            var radiusToCheck = 4;
-            var centerPosition = position;
-            for (var j = centerPosition.intY - radiusToCheck; j < centerPosition.intY + radiusToCheck; j++)
-            {
-                for (var i = centerPosition.intX - radiusToCheck; i < centerPosition.intX + radiusToCheck; i++)
-                {
-                    var cPos = new Position(i, j);
-                    if (!zone.Size.Contains(cPos.intX, cPos.intY))
-                        continue;
-
-                    var controlInfo = zone.Terrain.Controls.GetValue(position.intX, position.intY);
-                    if (controlInfo.IsAnyTerraformProtected || !zone.Terrain.Slope.CheckSlope(cPos.intX, cPos.intY, ZoneExtensions.MIN_SLOPE))
-                    {
-                        return false;
-                    }
-                }
-            }
-            return !IsInRange(position, range);
-        }
-
-        protected override Position FindSpawnPosition()
-        {
-            return _presence.PathFinder.FindSpawnPosition(_presence).ToPosition();
-        }
-    }
-
-    public class GrowthState : NullRoamingState
-    {
-        private readonly GrowingPresence _growingPresence;
-        private readonly TimeTracker _timer;
-        private int _currentLevel = 0;
-        public GrowthState(GrowingPresence presence) : base(presence)
-        {
-            _growingPresence = presence;
-            _timer = new TimeTracker(_growingPresence.GrowTime);
-            _currentLevel = _growingPresence.CurrentGrowthLevel;
-        }
-
-        public override void Update(TimeSpan time)
-        {
-            if (IsRunningTask)
-                return;
-
-            var members = GetAllMembers();
-            if (IsDeadAndExiting(members))
-                return;
-
-            if (!NextWaveReady(time))
-                return;
-
-            RunTask(() => SpawnNextWave(), t => { });
-        }
-
-        private bool NextWaveReady(TimeSpan time)
-        {
-            if (!CheckTimer(time))
-                return false;
-
-            _currentLevel++;
-            return true;
-        }
-
-        private bool CheckTimer(TimeSpan time)
-        {
-            _timer.Update(time);
-            if (!_timer.Expired)
-                return false;
-
-            _timer.Reset();
-            return true;
-        }
-
-        private void SpawnNextWave()
-        {
-            var flockConfigs = _growingPresence.Selector.GetFlocksForPresenceLevel(_growingPresence, _currentLevel);
-            foreach (var config in flockConfigs)
-            {
-                var flock = _growingPresence.CreateAndAddFlock(config);
-                flock.SpawnAllMembers();
-            }
-            _growingPresence.OnWaveSpawn(_currentLevel);
         }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/StaticExpiringFlock.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/StaticExpiringFlock.cs
@@ -1,4 +1,5 @@
 ﻿using Perpetuum.Zones.NpcSystem.Flocks;
+using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
 
 namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
 {
@@ -8,7 +9,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
 
         protected override bool IsPresenceInSpawningState()
         {
-            if (Presence is RandomSpawningExpiringPresence pres)
+            if (Presence is IRandomStaticPresence pres)
             {
                 return pres.StackFSM.Current is StaticSpawnState;
             }
@@ -17,7 +18,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence
 
         protected override Position GetSpawnPosition(Position spawnOrigin)
         {
-            if (Presence is RandomSpawningExpiringPresence pres)
+            if (Presence is IRandomStaticPresence pres)
             {
                 spawnOrigin = pres.SpawnOrigin.Clamp(Presence.Zone.Size);
             }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/StaticSpawnState.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/StaticSpawnState.cs
@@ -9,8 +9,8 @@ namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
 {
     public class StaticSpawnState : SpawnState
     {
-        private int _baseRadius = 300;
-        private int _teleRadius = 150;
+        private readonly int _baseRadius = 300;
+        private readonly int _teleRadius = 150;
         public StaticSpawnState(IRoamingPresence presence, int playerMinDist = 200, int baseDist = 300, int teleportDist = 150) : base(presence, playerMinDist)
         {
             _baseRadius = baseDist;
@@ -35,7 +35,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
             else if (zone.PresenceManager.GetPresences().OfType<IRandomStaticPresence>().Where(p => p.SpawnOrigin.IsInRangeOf2D(position, _baseRadius)).Any())
                 return true;
 
-            return zone.Players.WithinRange2D(position, range).Any();
+            return base.IsInRange(position, range);
         }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/StaticSpawnState.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/ExpiringStaticPresence/StaticSpawnState.cs
@@ -1,0 +1,41 @@
+﻿using Perpetuum.ExportedTypes;
+using Perpetuum.Units;
+using Perpetuum.Units.DockingBases;
+using Perpetuum.Zones.NpcSystem.Presences.PathFinders;
+using Perpetuum.Zones.Teleporting;
+using System.Linq;
+
+namespace Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence
+{
+    public class StaticSpawnState : SpawnState
+    {
+        private int _baseRadius = 300;
+        private int _teleRadius = 150;
+        public StaticSpawnState(IRoamingPresence presence, int playerMinDist = 200, int baseDist = 300, int teleportDist = 150) : base(presence, playerMinDist)
+        {
+            _baseRadius = baseDist;
+            _teleRadius = teleportDist;
+        }
+
+        protected override void OnSpawned()
+        {
+            _presence.OnSpawned();
+            _presence.StackFSM.Push(new NullRoamingState(_presence));
+        }
+
+        protected override bool IsInRange(Position position, int range)
+        {
+            var zone = _presence.Zone;
+            if (zone.Configuration.IsGamma && zone.IsUnitWithCategoryInRange(CategoryFlags.cf_pbs_docking_base, position, _baseRadius))
+                return true;
+            else if (zone.GetStaticUnits().OfType<DockingBase>().WithinRange2D(position, _baseRadius).Any())
+                return true;
+            else if (zone.GetStaticUnits().OfType<Teleport>().WithinRange2D(position, _teleRadius).Any())
+                return true;
+            else if (zone.PresenceManager.GetPresences().OfType<IRandomStaticPresence>().Where(p => p.SpawnOrigin.IsInRangeOf2D(position, _baseRadius)).Any())
+                return true;
+
+            return zone.Players.WithinRange2D(position, range).Any();
+        }
+    }
+}

--- a/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingNPCBasePresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingNPCBasePresence.cs
@@ -1,0 +1,16 @@
+﻿using Perpetuum.StateMachines;
+using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
+
+namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
+{
+    public class GrowingNPCBasePresence : GrowingPresence
+    {
+        public GrowingNPCBasePresence(IZone zone, IPresenceConfiguration configuration, IEscalatingPresenceFlockSelector selector) : base(zone, configuration, selector) { }
+        protected override void InitStateMachine()
+        {
+            CurrentGrowthLevel = FastRandom.NextInt(9);
+            StackFSM = new StackFSM();
+            StackFSM.Push(new NPCBaseSpawnState(this));
+        }
+    }
+}

--- a/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingNPCBasePresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingNPCBasePresence.cs
@@ -1,5 +1,6 @@
 ﻿using Perpetuum.StateMachines;
 using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
+using System.Linq;
 
 namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
 {
@@ -11,6 +12,18 @@ namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
             CurrentGrowthLevel = FastRandom.NextInt(9);
             StackFSM = new StackFSM();
             StackFSM.Push(new NPCBaseSpawnState(this));
+        }
+    }
+
+    public static class NPCBasePresenceUtils
+    {
+        public static bool WithinRangeOfNPCBase(IZone zone, Position from, double range = DistanceConstants.PBS_DIST_FROM_NPC_BASE)
+        {
+            return zone.PresenceManager.GetPresences()
+                .OfType<GrowingNPCBasePresence>()
+                .Where(p => p.Members.Count() > 0)
+                .Select(p => p.SpawnOrigin)
+                .Any(pos => pos.TotalDistance2D(from) < range);
         }
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingPresence.cs
@@ -1,0 +1,52 @@
+﻿using Perpetuum.StateMachines;
+using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
+using Perpetuum.Zones.NpcSystem.Presences.RandomExpiringPresence;
+using System;
+
+namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
+{
+    public class GrowingPresence : RandomSpawningExpiringPresence
+    {
+        public TimeSpan GrowTime { get; private set; }
+        public IEscalatingPresenceFlockSelector Selector { get; private set; }
+        public int CurrentGrowthLevel { get; private set; }
+        public GrowingPresence(IZone zone, IPresenceConfiguration configuration, IEscalatingPresenceFlockSelector selector) : base(zone, configuration)
+        {
+            Selector = selector;
+            if (Configuration.GrowthSeconds != null)
+                GrowTime = TimeSpan.FromSeconds((int)Configuration.GrowthSeconds);
+        }
+
+        protected override void InitStateMachine()
+        {
+            CurrentGrowthLevel = FastRandom.NextInt(9);
+            StackFSM = new StackFSM();
+            StackFSM.Push(new NPCBaseGrowState(this));
+        }
+
+        public override void LoadFlocks()
+        {
+            for (var i = 0; i <= CurrentGrowthLevel; i++)
+            {
+                var flockConfigs = Selector.GetFlocksForPresenceLevel(this, i);
+                foreach (var config in flockConfigs)
+                {
+                    CreateAndAddFlock(config);
+                }
+            }
+        }
+
+        public void OnWaveSpawn(int level)
+        {
+            CurrentGrowthLevel = Math.Max(CurrentGrowthLevel, level);
+        }
+
+        protected override void OnPresenceExpired()
+        {
+            base.OnPresenceExpired();
+            ClearFlocks();
+            CurrentGrowthLevel = 0;
+            LoadFlocks();
+        }
+    }
+}

--- a/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingPresence.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowingPresence.cs
@@ -5,11 +5,17 @@ using System;
 
 namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
 {
-    public class GrowingPresence : RandomSpawningExpiringPresence
+    public interface IGrowingPresence
+    {
+        TimeSpan GrowTime { get; }
+        IEscalatingPresenceFlockSelector Selector { get; }
+        int CurrentGrowthLevel { get; }
+    }
+    public class GrowingPresence : RandomSpawningExpiringPresence, IGrowingPresence
     {
         public TimeSpan GrowTime { get; private set; }
-        public IEscalatingPresenceFlockSelector Selector { get; private set; }
-        public int CurrentGrowthLevel { get; private set; }
+        public virtual IEscalatingPresenceFlockSelector Selector { get; protected set; }
+        public int CurrentGrowthLevel { get; protected set; }
         public GrowingPresence(IZone zone, IPresenceConfiguration configuration, IEscalatingPresenceFlockSelector selector) : base(zone, configuration)
         {
             Selector = selector;
@@ -19,16 +25,15 @@ namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
 
         protected override void InitStateMachine()
         {
-            CurrentGrowthLevel = FastRandom.NextInt(9);
             StackFSM = new StackFSM();
-            StackFSM.Push(new NPCBaseGrowState(this));
+            StackFSM.Push(new GrowSpawnState(this));
         }
 
         public override void LoadFlocks()
         {
             for (var i = 0; i <= CurrentGrowthLevel; i++)
             {
-                var flockConfigs = Selector.GetFlocksForPresenceLevel(this, i);
+                var flockConfigs = Selector.GetFlocksForPresenceLevel(ID, i);
                 foreach (var config in flockConfigs)
                 {
                     CreateAndAddFlock(config);

--- a/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowthStates.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowthStates.cs
@@ -1,0 +1,132 @@
+﻿using Perpetuum.Timers;
+using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
+using Perpetuum.Zones.NpcSystem.Presences.PathFinders;
+using System;
+
+namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
+{
+    public class GrowSpawnState : StaticSpawnState
+    {
+        private readonly GrowingPresence _growingPresence;
+        public GrowSpawnState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist)
+        {
+            _growingPresence = presence;
+        }
+
+        protected override void OnSpawned()
+        {
+            _presence.OnSpawned();
+            _presence.StackFSM.Push(new GrowthState(_growingPresence));
+        }
+    }
+
+    public class NPCBaseGrowState : GrowSpawnState
+    {
+        private readonly GrowingPresence _growingPresence;
+        public NPCBaseGrowState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist)
+        {
+            _growingPresence = presence;
+        }
+
+        protected override void SetSpawnDelay()
+        {
+            if (_growingPresence.CurrentGrowthLevel == 0)
+            {
+                _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
+            }
+            _delay = TimeSpan.FromSeconds((int)_presence.Configuration.DynamicLifeTime * _repawnDelayModifier);
+            _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
+        }
+
+        protected override bool IsValidSpawnPosition(Position position, int range)
+        {
+            var zone = _presence.Zone;
+            if (zone == null)
+            {
+                return false;
+            }
+
+            var radiusToCheck = 4;
+            var centerPosition = position;
+            for (var j = centerPosition.intY - radiusToCheck; j < centerPosition.intY + radiusToCheck; j++)
+            {
+                for (var i = centerPosition.intX - radiusToCheck; i < centerPosition.intX + radiusToCheck; i++)
+                {
+                    var cPos = new Position(i, j);
+                    if (!zone.Size.Contains(cPos.intX, cPos.intY))
+                        continue;
+
+                    var controlInfo = zone.Terrain.Controls.GetValue(position.intX, position.intY);
+                    if (controlInfo.IsAnyTerraformProtected || !zone.Terrain.Slope.CheckSlope(cPos.intX, cPos.intY, ZoneExtensions.MIN_SLOPE))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return !IsInRange(position, range);
+        }
+
+        protected override Position FindSpawnPosition()
+        {
+            return _presence.PathFinder.FindSpawnPosition(_presence).ToPosition();
+        }
+    }
+
+    public class GrowthState : NullRoamingState
+    {
+        private readonly GrowingPresence _growingPresence;
+        private readonly TimeTracker _timer;
+        private int _currentLevel = 0;
+        public GrowthState(GrowingPresence presence) : base(presence)
+        {
+            _growingPresence = presence;
+            _timer = new TimeTracker(_growingPresence.GrowTime);
+            _currentLevel = _growingPresence.CurrentGrowthLevel;
+        }
+
+        public override void Update(TimeSpan time)
+        {
+            if (IsRunningTask)
+                return;
+
+            var members = GetAllMembers();
+            if (IsDeadAndExiting(members))
+                return;
+
+            if (!NextWaveReady(time))
+                return;
+
+            RunTask(() => SpawnNextWave(), t => { });
+        }
+
+        private bool NextWaveReady(TimeSpan time)
+        {
+            if (!CheckTimer(time))
+                return false;
+
+            _currentLevel++;
+            return true;
+        }
+
+        private bool CheckTimer(TimeSpan time)
+        {
+            _timer.Update(time);
+            if (!_timer.Expired)
+                return false;
+
+            _timer.Reset();
+            return true;
+        }
+
+        private void SpawnNextWave()
+        {
+            var flockConfigs = _growingPresence.Selector.GetFlocksForPresenceLevel(_growingPresence, _currentLevel);
+            foreach (var config in flockConfigs)
+            {
+                var flock = _growingPresence.CreateAndAddFlock(config);
+                flock.SpawnAllMembers();
+            }
+            _growingPresence.OnWaveSpawn(_currentLevel);
+        }
+    }
+}

--- a/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowthStates.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/GrowingPresences/GrowthStates.cs
@@ -8,7 +8,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
     public class GrowSpawnState : StaticSpawnState
     {
         private readonly GrowingPresence _growingPresence;
-        public GrowSpawnState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist)
+        public GrowSpawnState(GrowingPresence presence) : base(presence)
         {
             _growingPresence = presence;
         }
@@ -20,12 +20,18 @@ namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
         }
     }
 
-    public class NPCBaseGrowState : GrowSpawnState
+    public class NPCBaseSpawnState : GrowSpawnState
     {
-        private readonly GrowingPresence _growingPresence;
-        public NPCBaseGrowState(GrowingPresence presence, int playerMinDist = 200) : base(presence, playerMinDist)
+        private readonly GrowingNPCBasePresence _growingPresence;
+        public NPCBaseSpawnState(GrowingNPCBasePresence presence) : base(presence)
         {
             _growingPresence = presence;
+        }
+
+        protected override void OnSpawned()
+        {
+            _presence.OnSpawned();
+            _presence.StackFSM.Push(new NPCBaseGrowthState(_growingPresence));
         }
 
         protected override void SetSpawnDelay()
@@ -40,30 +46,40 @@ namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
 
         protected override bool IsValidSpawnPosition(Position position, int range)
         {
+            if (!IsLocalRadiusClearForBase(position))
+                return false;
+
+            return !IsInRange(position, range);
+        }
+        private bool IsLocalRadiusClearForBase(Position center, int radius = 5)
+        {
             var zone = _presence.Zone;
             if (zone == null)
-            {
                 return false;
-            }
 
-            var radiusToCheck = 4;
-            var centerPosition = position;
-            for (var j = centerPosition.intY - radiusToCheck; j < centerPosition.intY + radiusToCheck; j++)
+            int minX = (center.intX - radius).Clamp(0, zone.Size.Width - 1);
+            int maxX = (center.intX + radius).Clamp(0, zone.Size.Width - 1);
+            int minY = (center.intY - radius).Clamp(0, zone.Size.Height - 1);
+            int maxY = (center.intY + radius).Clamp(0, zone.Size.Height - 1);
+
+            var check = false;
+            for (var j = minY; j < maxY; j++)
             {
-                for (var i = centerPosition.intX - radiusToCheck; i < centerPosition.intX + radiusToCheck; i++)
+                for (var i = minX; i < maxX; i++)
                 {
                     var cPos = new Position(i, j);
                     if (!zone.Size.Contains(cPos.intX, cPos.intY))
                         continue;
 
-                    var controlInfo = zone.Terrain.Controls.GetValue(position.intX, position.intY);
+                    var controlInfo = zone.Terrain.Controls.GetValue(cPos.intX, cPos.intY);
                     if (controlInfo.IsAnyTerraformProtected || !zone.Terrain.Slope.CheckSlope(cPos.intX, cPos.intY, ZoneExtensions.MIN_SLOPE))
                     {
                         return false;
                     }
+                    check = true;
                 }
             }
-            return !IsInRange(position, range);
+            return check;
         }
 
         protected override Position FindSpawnPosition()
@@ -72,11 +88,19 @@ namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
         }
     }
 
+    public class NPCBaseGrowthState : GrowthState
+    {
+        public NPCBaseGrowthState(GrowingNPCBasePresence presence) : base(presence)
+        {
+            _currentLevel = presence.CurrentGrowthLevel;
+        }
+    }
+
     public class GrowthState : NullRoamingState
     {
         private readonly GrowingPresence _growingPresence;
         private readonly TimeTracker _timer;
-        private int _currentLevel = 0;
+        protected int _currentLevel = 0;
         public GrowthState(GrowingPresence presence) : base(presence)
         {
             _growingPresence = presence;
@@ -120,7 +144,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.GrowingPresences
 
         private void SpawnNextWave()
         {
-            var flockConfigs = _growingPresence.Selector.GetFlocksForPresenceLevel(_growingPresence, _currentLevel);
+            var flockConfigs = _growingPresence.Selector.GetFlocksForPresenceLevel(_growingPresence.ID, _currentLevel);
             foreach (var config in flockConfigs)
             {
                 var flock = _growingPresence.CreateAndAddFlock(config);

--- a/src/Perpetuum/Zones/NpcSystem/Presences/IPresenceConfiguration.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/IPresenceConfiguration.cs
@@ -22,6 +22,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences
         bool IsRespawnAllowed { get; }
 
         int? InterzoneGroupId { get; }
+        int? GrowthSeconds { get; }
 
         int ZoneID { get; }
 

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/RoamingStates.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/RoamingStates.cs
@@ -46,10 +46,10 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
     public class SpawnState : CancellableState, IState
     {
         protected readonly IRoamingPresence _presence;
-        private TimeSpan _delay = TimeSpan.Zero;
+        protected TimeSpan _delay = TimeSpan.Zero;
 
         protected bool _spawned;
-        private double _repawnDelayModifier = 0.0;
+        protected double _repawnDelayModifier = 0.0;
 
         protected readonly int _playerMinDist;
 
@@ -57,6 +57,12 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
         {
             _presence = presence;
             _playerMinDist = playerMinDist;
+        }
+
+        protected virtual void SetSpawnDelay()
+        {
+            _delay = TimeSpan.FromSeconds(_presence.Configuration.RoamingRespawnSeconds * _repawnDelayModifier);
+            _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
         }
 
         public void Enter()
@@ -69,8 +75,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
 
             _elapsed = TimeSpan.Zero;
 
-            _delay = TimeSpan.FromSeconds(_presence.Configuration.RoamingRespawnSeconds * _repawnDelayModifier);
-            _repawnDelayModifier = FastRandom.NextDouble(1.0, 2.0);
+            SetSpawnDelay();
         }
 
         public void Exit()
@@ -117,7 +122,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
 
         protected virtual bool IsValidSpawnPosition(Position position, int range)
         {
-            return IsInRange(position, range);
+            return !IsInRange(position, range);
         }
 
         protected virtual Position FindSpawnPosition()
@@ -128,9 +133,8 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
         private void SpawnFlocks()
         {
             Position spawnPosition;
-            bool anyPlayersAround;
             int range = _playerMinDist;
-
+            bool isValidSpawnLocation;
             do
             {
                 if (IsCancelled)
@@ -139,11 +143,11 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
                     return;
                 }
                 spawnPosition = FindSpawnPosition();
-                anyPlayersAround = IsValidSpawnPosition(spawnPosition, range);
+                isValidSpawnLocation = IsValidSpawnPosition(spawnPosition, range);
                 range--;
-            } while (anyPlayersAround && range > 0);
+            } while (!isValidSpawnLocation && range > 0);
 
-            if (anyPlayersAround)
+            if (!isValidSpawnLocation)
             {
                 _presence.Log("FAILED to resolve spawn position out of range of players: " + spawnPosition);
                 return;

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/RoamingStates.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/RoamingStates.cs
@@ -115,6 +115,16 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
             return _presence.Zone.Players.WithinRange(position, range).Any();
         }
 
+        protected virtual bool IsValidSpawnPosition(Position position, int range)
+        {
+            return IsInRange(position, range);
+        }
+
+        protected virtual Position FindSpawnPosition()
+        {
+            return _presence.PathFinder.FindSpawnPosition(_presence).ToPosition();
+        }
+
         private void SpawnFlocks()
         {
             Position spawnPosition;
@@ -128,8 +138,8 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
                     Logger.Warning("SpawnFlocks() cancelled");
                     return;
                 }
-                spawnPosition = _presence.PathFinder.FindSpawnPosition(_presence).ToPosition();
-                anyPlayersAround = IsInRange(spawnPosition, range);
+                spawnPosition = FindSpawnPosition();
+                anyPlayersAround = IsValidSpawnPosition(spawnPosition, range);
                 range--;
             } while (anyPlayersAround && range > 0);
 

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PresenceConfiguration.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PresenceConfiguration.cs
@@ -24,6 +24,8 @@ namespace Perpetuum.Zones.NpcSystem.Presences
 
         public int? InterzoneGroupId { get; set; }
 
+        public int? GrowthSeconds { get; set; }
+
         public int ZoneID { get; set; }
 
         public Position RandomCenter => new Position((double)RandomCenterX, (double)RandomCenterY);

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PresenceConfigurationReader.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PresenceConfigurationReader.cs
@@ -46,6 +46,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences
                 RandomRadius = record.GetValue<int?>("randomradius"),
                 DynamicLifeTime = record.GetValue<int?>("dynamiclifetime"),
                 IsRespawnAllowed = record.GetValue<bool>("isrespawnallowed"),
+                GrowthSeconds = record.GetValue<int?>("growthseconds"),
                 Area = new Area(topX, topY, bottomX, bottomY)
             };
             return p;

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PresenceType.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PresenceType.cs
@@ -12,6 +12,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences
         Interzone = 7,
         InterzoneRoaming = 8,
         DynamicExtended = 9,
-        ExpiringRandom = 10
+        ExpiringRandom = 10,
+        EscalatingRandomPresence = 11
     }
 }

--- a/src/Perpetuum/Zones/NpcSystem/Presences/PresenceType.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PresenceType.cs
@@ -13,6 +13,7 @@ namespace Perpetuum.Zones.NpcSystem.Presences
         InterzoneRoaming = 8,
         DynamicExtended = 9,
         ExpiringRandom = 10,
-        EscalatingRandomPresence = 11
+        EscalatingRandomPresence = 11,
+        GrowingNPCBasePresence = 12
     }
 }

--- a/src/Perpetuum/Zones/PBS/PBSDeployer.cs
+++ b/src/Perpetuum/Zones/PBS/PBSDeployer.cs
@@ -3,6 +3,8 @@ using Perpetuum.EntityFramework;
 using Perpetuum.Groups.Corporations;
 using Perpetuum.Players;
 using Perpetuum.Units;
+using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
+using System.Linq;
 
 namespace Perpetuum.Zones.PBS
 {
@@ -33,6 +35,14 @@ namespace Perpetuum.Zones.PBS
 
             //check zone for conditions
             PBSHelper.CheckZoneForDeployment(zone, spawnPosition,pbsEd).ThrowIfError();
+
+            //Check distance to NPC Base spawns
+            var isCloseToNPCBase = zone.PresenceManager.GetPresences()
+                .OfType<IRandomStaticPresence>()
+                .Where(p => p.Flocks.Count(f => f.Members.Count > 0) > 0)
+                .Select(p => p.SpawnOrigin)
+                .Any(pos=> pos.TotalDistance2D(spawnPosition) < DistanceConstants.PBS_DIST_FROM_NPC_BASE);
+            isCloseToNPCBase.ThrowIfTrue(ErrorCodes.TooCloseToNPCBase);
 
             //pass owner
             pbsEgg.DeployerPlayer = player;

--- a/src/Perpetuum/Zones/PBS/PBSDeployer.cs
+++ b/src/Perpetuum/Zones/PBS/PBSDeployer.cs
@@ -3,8 +3,7 @@ using Perpetuum.EntityFramework;
 using Perpetuum.Groups.Corporations;
 using Perpetuum.Players;
 using Perpetuum.Units;
-using Perpetuum.Zones.NpcSystem.Presences.ExpiringStaticPresence;
-using System.Linq;
+using Perpetuum.Zones.NpcSystem.Presences.GrowingPresences;
 
 namespace Perpetuum.Zones.PBS
 {
@@ -37,12 +36,7 @@ namespace Perpetuum.Zones.PBS
             PBSHelper.CheckZoneForDeployment(zone, spawnPosition,pbsEd).ThrowIfError();
 
             //Check distance to NPC Base spawns
-            var isCloseToNPCBase = zone.PresenceManager.GetPresences()
-                .OfType<IRandomStaticPresence>()
-                .Where(p => p.Flocks.Count(f => f.Members.Count > 0) > 0)
-                .Select(p => p.SpawnOrigin)
-                .Any(pos=> pos.TotalDistance2D(spawnPosition) < DistanceConstants.PBS_DIST_FROM_NPC_BASE);
-            isCloseToNPCBase.ThrowIfTrue(ErrorCodes.TooCloseToNPCBase);
+            NPCBasePresenceUtils.WithinRangeOfNPCBase(zone, spawnPosition).ThrowIfTrue(ErrorCodes.TooCloseToNPCBase);
 
             //pass owner
             pbsEgg.DeployerPlayer = player;


### PR DESCRIPTION
Closes: #357

This PR... is a lot
 - It builds on the RandomSpawningExpiringPresence which determines random spawn locations for static spawns
 - Provides another subclass `GrowingPresence` with a state that increments levels and selects new npcs from the `npcescalations` table (see DB PR)
 Requires: from OPDB/Gamma branch https://github.com/OpenPerpetuum/OPDB/tree/GAMMA
 ```
Staging_Dev/10_npcEscalations_createtable_col__2021_09_18.sql
Staging_Dev/11_insert_npcdefs_npcturrets__2021_09_18.sql
Staging_Dev/12_insert_npcpres_flocks_waves_npcbases__2021_09_18.sql
```
Or just 10, and you can build your own presences with type=12

But things the team wants still:
 - Respawning at non-initial states/levels ✔️ 
 - To only respawn in non-redzone tiles (spawn state to check this) ✔️ 
 - Respawning delay and lifetime to have random noise for their scheduling ✔️ 
 - ~~NPC definitions that if present, can alter/create a zone effect (TODO: make separate issue)~~ #392 
 - NPC definitions that if present, players can not place PBS structures nearby (at least terminals) (radius TBD) ✔️ 
 