### PR TITLE
Staging terminal: no wall/gate

### DIFF
--- a/src/Perpetuum/Zones/PBS/PBSHelper.cs
+++ b/src/Perpetuum/Zones/PBS/PBSHelper.cs
@@ -1597,7 +1597,11 @@ killercharacterid
                 unitsInZone.WithinRange(targetPosition, DistanceConstants.PLANT_MAX_DISTANCE_FROM_PBS)
                     .Any(u =>
                     {
-                        if (u is PBSDockingBase || u is PBSControlTower)
+                        if (u is ExpiringPBSDockingBase)
+                        {
+                            return false;
+                        }
+                        else if (u is PBSDockingBase || u is PBSControlTower)
                         {
                             if (u.Owner == corporationEid)
                                 return true;


### PR DESCRIPTION
Staging terminal does not provide radius for corp members to anchor walls/gates as they are temporary and could be abused as means to wall areas greater than their more permanent bases allow.

Closes: #436 