### PR TITLE
Staging term expire time persistence

### DIFF
--- a/src/Perpetuum/Zones/PBS/DockingBases/ExpiringPBSDockingBase.cs
+++ b/src/Perpetuum/Zones/PBS/DockingBases/ExpiringPBSDockingBase.cs
@@ -16,6 +16,7 @@ namespace Perpetuum.Zones.PBS.DockingBases
         private IUnitDespawnHelper _despawnHelper;
         private TimeSpan _aliveElapsed;
         private readonly TimeSpan _alertPeriod = TimeSpan.FromHours(1);
+        private readonly TimeSpan _minLife = TimeSpan.FromMinutes(1);
         private const int MIN_LIFE_HOURS = 72;
         private bool _alerted;
 
@@ -46,9 +47,25 @@ namespace Perpetuum.Zones.PBS.DockingBases
             }
         }
 
+        public DateTime EndTime
+        {
+            get
+            {
+                return DynamicProperties.GetOrAdd(k.endTime, () => DateTime.Now + LifeTime);
+            }
+        }
+
+        public TimeSpan Remaining
+        {
+            get
+            {
+                return (EndTime - DateTime.Now).Max(_minLife);
+            }
+        }
+
         protected override void OnEnterZone(IZone zone, ZoneEnterType enterType)
         {
-            _despawnHelper = UnitDespawnHelper.Create(this, LifeTime);
+            _despawnHelper = UnitDespawnHelper.Create(this, Remaining);
             _despawnHelper.DespawnStrategy = Kill;
 
             base.OnEnterZone(zone, enterType);

--- a/src/Perpetuum/Zones/PBS/DockingBases/ExpiringPBSDockingBase.cs
+++ b/src/Perpetuum/Zones/PBS/DockingBases/ExpiringPBSDockingBase.cs
@@ -14,9 +14,8 @@ namespace Perpetuum.Zones.PBS.DockingBases
     public class ExpiringPBSDockingBase : PBSDockingBase
     {
         private IUnitDespawnHelper _despawnHelper;
-        private TimeSpan _aliveElapsed;
         private readonly TimeSpan _alertPeriod = TimeSpan.FromHours(1);
-        private readonly TimeSpan _minLife = TimeSpan.FromMinutes(1);
+        private readonly TimeSpan _minLife = TimeSpan.FromMinutes(5);
         private const int MIN_LIFE_HOURS = 72;
         private bool _alerted;
 
@@ -66,28 +65,30 @@ namespace Perpetuum.Zones.PBS.DockingBases
         protected override void OnEnterZone(IZone zone, ZoneEnterType enterType)
         {
             _despawnHelper = UnitDespawnHelper.Create(this, Remaining);
-            _despawnHelper.DespawnStrategy = Kill;
+            _despawnHelper.DespawnStrategy = (unit) =>
+            {
+                ReinforceHandler.ReinforceCounter = 0;
+                Kill();
+            };
 
             base.OnEnterZone(zone, enterType);
         }
 
         protected override void OnUpdate(TimeSpan time)
         {
-            if (!_alerted)
-                WarnIfAboutToExpire(time);
+            WarnIfAboutToExpire();
 
             _despawnHelper?.Update(time, this);
 
             base.OnUpdate(time);
         }
 
-        private void WarnIfAboutToExpire(TimeSpan time)
+        private void WarnIfAboutToExpire()
         {
-            _aliveElapsed += time;
-            if (LifeTime - _aliveElapsed < _alertPeriod)
+            if (!_alerted && Remaining < _alertPeriod)
             {
-                Task.Run(() => _pbsObjectHelper.SendAttackAlert());
                 _alerted = true;
+                Task.Run(() => _pbsObjectHelper.SendAttackAlert());
             }
         }
 


### PR DESCRIPTION
Write to unused dynamic property on staging terminal entity
Updates when entity is updated automatically, including on a clean shutdown
Reads in with other props are startup and resets timer to remaining duration

Closes: #440 