### PR TITLE
Gamma corp hangar fix

### DIFF
--- a/src/Perpetuum/Robots/Robot.cs
+++ b/src/Perpetuum/Robots/Robot.cs
@@ -136,7 +136,9 @@ namespace Perpetuum.Robots
                     return base.Health;
                 }
 
-                return Armor.Ratio(ArmorMax) * 100;
+                return ArmorMax > 0.0 && Armor > 0.0
+                    ? Armor.Ratio(ArmorMax) * 100
+                    : base.Health;
             }
         }
 


### PR DESCRIPTION
Added check that Armor and ArmorMax are greater than zero (i.e. initialized) when calculating health