### PR TITLE
Control access to docking base chat

### DIFF
--- a/src/Perpetuum.RequestHandlers/BaseSetDockingRights.cs
+++ b/src/Perpetuum.RequestHandlers/BaseSetDockingRights.cs
@@ -70,6 +70,7 @@ namespace Perpetuum.RequestHandlers
 
                 outpost.SetDockingControlDetails(standingLimit, !lockBase);
                 outpost.InsertDockingRightsLog(character, standingLimit, corporationEid, eventType);
+                outpost.CheckDockedCharacters();
 
                 Transaction.Current.OnCommited(() => outpost.SendSiteInfoToOnlineCharacters());
 

--- a/src/Perpetuum.RequestHandlers/Characters/CharacterSelect.cs
+++ b/src/Perpetuum.RequestHandlers/Characters/CharacterSelect.cs
@@ -37,15 +37,12 @@ namespace Perpetuum.RequestHandlers.Characters
             {
                 character.Nick = character.Nick.Replace("_renamed_", "");
                 character.LastUsed = DateTime.Now;
-                character.IsDocked = isDocked;
                 character.Language = request.Data.GetOrDefault<int>(k.language);
                 character.IsOnline = true;
 
                 if (isDocked)
                 {
-                    character.ZoneId = null;
-                    character.ZonePosition = null;
-                    character.GetCurrentDockingBase()?.JoinChannel(character);
+                    character.GetCurrentDockingBase()?.DockIn(character, TimeSpan.Zero);
                 }
 
                 var corporation = character.GetCorporation();

--- a/src/Perpetuum.RequestHandlers/Sparks/SparkTeleportUse.cs
+++ b/src/Perpetuum.RequestHandlers/Sparks/SparkTeleportUse.cs
@@ -44,6 +44,9 @@ namespace Perpetuum.RequestHandlers.Sparks
                     throw new PerpetuumException(ErrorCodes.YouAreHereAlready);
 
                 sparkTeleport.DockingBase.IsDockingAllowed(character).ThrowIfError();
+
+                // Teleport action
+                currentDockingBase.DockOut(character);
                 sparkTeleport.DockingBase.DockIn(character, Player.NormalUndockDelay);
 
                 var robot = sparkTeleport.DockingBase.GetPublicContainerWithItems(character)
@@ -55,8 +58,6 @@ namespace Perpetuum.RequestHandlers.Sparks
 
                 Transaction.Current.OnCommited(() =>
                 {
-                    currentDockingBase.LeaveChannel(character);
-
                     Message.Builder.FromRequest(request)
                         .WithData(sparkTeleport.ToDictionary())
                         .Send();

--- a/src/Perpetuum.RequestHandlers/Zone/PBS/PBSSetStandingLimit.cs
+++ b/src/Perpetuum.RequestHandlers/Zone/PBS/PBSSetStandingLimit.cs
@@ -4,6 +4,7 @@ using Perpetuum.Groups.Corporations;
 using Perpetuum.Host.Requests;
 using Perpetuum.Zones;
 using Perpetuum.Zones.PBS;
+using Perpetuum.Zones.PBS.DockingBases;
 
 namespace Perpetuum.RequestHandlers.Zone.PBS
 {
@@ -43,6 +44,7 @@ namespace Perpetuum.RequestHandlers.Zone.PBS
                 }
 
                 ((IHaveStandingLimit)sourceUnit).StandingLimit = standingLimit ?? 0.0;
+                (sourceUnit as PBSDockingBase)?.CheckDockedCharacters();
 
                 sourceUnit.Save();
 

--- a/src/Perpetuum/Groups/Corporations/Corporation.Helpers.cs
+++ b/src/Perpetuum/Groups/Corporations/Corporation.Helpers.cs
@@ -19,7 +19,7 @@ namespace Perpetuum.Groups.Corporations
         [CanBeNull]
         public static Corporation Get(long eid)
         {
-            return (Corporation)Repository.Load(eid);
+            return Repository.Load(eid) as Corporation;
         }
 
         protected static Corporation Create(EntityDefault entityDefault, SystemContainer container, CorporationDescription corporationDescription, EntityIDGenerator generator)

--- a/src/Perpetuum/Groups/Corporations/PrivateCorporation.cs
+++ b/src/Perpetuum/Groups/Corporations/PrivateCorporation.cs
@@ -14,6 +14,7 @@ using Perpetuum.Services.Channels;
 using Perpetuum.Services.Insurance;
 using Perpetuum.Services.MarketEngine;
 using Perpetuum.Services.TechTree;
+using Perpetuum.Units.DockingBases;
 using Perpetuum.Zones;
 
 namespace Perpetuum.Groups.Corporations
@@ -26,8 +27,15 @@ namespace Perpetuum.Groups.Corporations
         private readonly IVoteHandler _voteHandler;
         private readonly CharacterWalletFactory _characterWalletFactory;
         private readonly IMarketOrderRepository _marketOrderRepository;
+        private readonly DockingBaseHelper _dockingBaseHelper;
 
-        public PrivateCorporation(ITechTreeService techTreeService,IChannelManager channelManager,IReadOnlyRepository<int,CharacterProfile> characterProfiles,IVoteHandler voteHandler,CharacterWalletFactory characterWalletFactory,IMarketOrderRepository marketOrderRepository)
+        public PrivateCorporation(ITechTreeService techTreeService,
+            IChannelManager channelManager,
+            IReadOnlyRepository<int,CharacterProfile> characterProfiles,
+            IVoteHandler voteHandler,
+            CharacterWalletFactory characterWalletFactory,
+            IMarketOrderRepository marketOrderRepository,
+            DockingBaseHelper dockingBaseHelper)
         {
             _techTreeService = techTreeService;
             _channelManager = channelManager;
@@ -35,6 +43,7 @@ namespace Perpetuum.Groups.Corporations
             _voteHandler = voteHandler;
             _characterWalletFactory = characterWalletFactory;
             _marketOrderRepository = marketOrderRepository;
+            _dockingBaseHelper = dockingBaseHelper;
         }
 
         public override IDictionary<string, object> GetInfoDictionaryForMember(Character member)
@@ -444,6 +453,18 @@ namespace Perpetuum.Groups.Corporations
         public new static PrivateCorporation Get(long eid)
         {
             return Corporation.GetOrThrow(eid) as PrivateCorporation;
+        }
+
+        /// <summary>
+        /// Corporation standing change
+        /// </summary>
+        /// <param name="targetEid">Target for standing</param>
+        public void OnStandingChange(long targetEid)
+        {
+            foreach(var b in _dockingBaseHelper.GetBySiteOwner(this))
+            {
+                b.CheckDockedCharacters();
+            }
         }
     }
 }

--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -1024,12 +1024,12 @@ namespace Perpetuum.Players
                     // ha bazisrol jott
                     zoneEnterType = ZoneEnterType.Undock;
 
-                    dockingBase = character.GetCurrentDockingBase();
-                    spawnPosition = UndockSpawnPositionSelector.SelectSpawnPosition(dockingBase);
+                    // Check undock condition.
+                    dockingBase = character.GetCurrentDockingBase().ThrowIfNull(ErrorCodes.DockingBaseNotFound);
+                    zone.Id.ThrowIfNotEqual(dockingBase.Zone.Id, ErrorCodes.InvalidZoneId);
 
-                    character.ZoneId = zone.Id;
-                    character.ZonePosition = spawnPosition;
-                    character.IsDocked = false;
+                    // Get spawn position and update undocked character.
+                    spawnPosition = dockingBase.DockOut(character, zoneEnterType).ThrowIfNull(ErrorCodes.InvalidPosition).Value;
                 }
                 else
                 {
@@ -1059,8 +1059,6 @@ namespace Perpetuum.Players
                 // csak akkor rakjuk ki ha volt rendes commit
                 Transaction.Current.OnCommited(() =>
                 {
-                    dockingBase?.LeaveChannel(character);
-
                     player.CorporationEid = character.CorporationEid;
                     zone.SetGang(player);
 

--- a/src/Perpetuum/Services/Channels/ChannelManager.cs
+++ b/src/Perpetuum/Services/Channels/ChannelManager.cs
@@ -44,30 +44,55 @@ namespace Perpetuum.Services.Channels
             session.CharacterDeselected += SessionOnCharacterDeselected;
         }
 
+        /// <summary>
+        /// Processing chat channels for an incoming character.
+        /// </summary>
+        /// <param name="session">Session for character.</param>
+        /// <param name="character"></param>
         private void SessionOnCharacterSelected(ISession session, Character character)
         {
+            // Get all chat channels for the character from the database.
             foreach (var kvp in _memberRepository.GetAllByCharacter(character))
             {
                 var channelName = kvp.Key;
                 var member = kvp.Value;
 
+                // Updating channel membership. 
                 var channel = UpdateChannel(channelName, c => c.SetMember(member));
+                // Inform everyone about entering the character online.
                 channel?.SendMemberOnlineStateToAll(_sessionManager, member, true);
             }
         }
 
+        /// <summary>
+        /// Processing chats for the outgoing character.
+        /// </summary>
+        /// <param name="session">Session for character.</param>
+        /// <param name="character"></param>
         private void SessionOnCharacterDeselected(ISession session, Character character)
         {
-            foreach (var name in _channels.Keys)
+            // Process all chat channels.
+            foreach (var kvp in _channels)
             {
-                ChannelMember m = null;
-                var channel = UpdateChannel(name, c =>
+                // If the character is not in a chat channel, then move on to the next channel.
+                var channel = kvp.Value;
+                var member = channel?.GetMember(character);
+                if (member == null)
                 {
-                    m = c.GetMember(character);
-                    return m == null ? c : c.RemoveMember(character);
-                });
+                    continue;
+                }
+                var channelName = kvp.Key;
 
-                channel?.SendMemberOnlineStateToAll(_sessionManager, m, false);
+                // Updating channel membership.
+                channel = UpdateChannel(channelName, c => c.RemoveMember(character));
+                // Inform everyone about entering the character online.
+                channel?.SendMemberOnlineStateToAll(_sessionManager, member, false);
+
+                // If this is a station channel, then we remove it from the channel in the database.
+                if (channel?.Type == ChannelType.Station)
+                {
+                    _memberRepository.Delete(channel, member);
+                }
             }
         }
 

--- a/src/Perpetuum/Services/Sessions/Session.cs
+++ b/src/Perpetuum/Services/Sessions/Session.cs
@@ -182,6 +182,12 @@ namespace Perpetuum.Services.Sessions
                 Character = Character.None;
                 _accessLevel = AccessLevel.normal;
             });
+
+            // After disconnect from channels in OnCharacterDeselected() call DockOut()
+            if (selectedCharacter.IsDocked)
+            {
+                selectedCharacter.GetCurrentDockingBase()?.DockOut(selectedCharacter);
+            }
         }
 
         public void Disconnect(bool safeLogout)

--- a/src/Perpetuum/Services/Standing/StandingHandler.cs
+++ b/src/Perpetuum/Services/Standing/StandingHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Perpetuum.Accounting.Characters;
+using Perpetuum.Groups.Corporations;
 using Perpetuum.Log;
 
 namespace Perpetuum.Services.Standing
@@ -57,6 +58,8 @@ namespace Perpetuum.Services.Standing
 
             GetOrAddStandingHolder(sourceEID).SetStanding(targetEID, standing);
             SendStandingDataChangedToHosts(info);
+
+            (Corporation.Get(sourceEID) as PrivateCorporation)?.OnStandingChange(targetEID);
         }
 
         public IDictionary<string, object> GetStandingsList(long sourceEID)

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -350,6 +350,66 @@ namespace Perpetuum.Units.DockingBases
         private ImmutableHashSet<Character> characters = ImmutableHashSet<Character>.Empty;
 
         /// <summary>
+        /// Performing check for docked characters.
+        /// </summary>
+        public void CheckDockedCharacters()
+        {
+            if (!characters.Any())
+            {
+                return;
+            }
+
+            // Statistic
+            int chTotal = 0;
+            int chNormalLeave = 0;
+            int chNormalJoin = 0;
+            int chInvalid = 0;
+
+            var channel = ChannelManager.GetChannelByName(ChannelName);
+            var transaction = Transaction.Current;
+
+            foreach (Character c in characters)
+            {
+                chTotal++;
+
+                var isOnline = c.IsOnline;
+                var isDocked = c.IsDocked;
+
+                if (!isOnline || !isDocked)
+                {
+                    chInvalid++;
+                    transaction.OnCommited(() => LeaveChannel(c));
+
+                    Logger.Warning($"[DockingBase]{this} Character:{c} isOnline:{c.IsOnline} isDocked:{c.IsDocked} IsDockingAllowed:{IsDockingAllowed(c)}");
+                    continue;
+                }
+
+                var isMember = channel.GetMember(c) != null;
+                var isAllowed = IsDockingAllowed(c) == ErrorCodes.NoError;
+
+                if (isMember == isAllowed)
+                {
+                    // Status match => all OK
+                    continue;
+                }
+
+                if (isAllowed)
+                {
+                    // ReJoin
+                    chNormalJoin++;
+                    transaction.OnCommited(() => JoinChannel(c));
+                    continue;
+                }
+
+                // Remove from channel
+                chNormalLeave++;
+                transaction.OnCommited(() => LeaveChannel(c));
+            }
+            
+            Logger.Info($"[DockingBase]{this} total:{chTotal} leave:{chNormalLeave} join:{chNormalJoin} invalid:{chInvalid}");
+        }
+
+        /// <summary>
         /// Site owner
         /// </summary>
         /// <returns>Site owner as corporation</returns>

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -173,6 +173,7 @@ namespace Perpetuum.Units.DockingBases
 
             if (ErrorCodes.NoError != IsDockingAllowed(character))
             {
+                Transaction.Current.OnCommited(() => LeaveChannel(character));
                 return;
             }
 

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -20,6 +20,7 @@ using Perpetuum.Services.ProductionEngine.Facilities;
 using Perpetuum.Zones;
 using Perpetuum.Zones.Intrusion;
 using Perpetuum.Zones.Training;
+using System.Collections.Immutable;
 
 namespace Perpetuum.Units.DockingBases
 {
@@ -167,6 +168,8 @@ namespace Perpetuum.Units.DockingBases
             character.ZoneId = null;
             character.ZonePosition = null;
 
+            ImmutableInterlocked.Update(ref characters, (c) => c.Add(character));
+
             Transaction.Current.OnCommited(() => JoinChannel(character));
         }
 
@@ -200,6 +203,8 @@ namespace Perpetuum.Units.DockingBases
         /// <param name="character">Character to undock</param>
         public void DockOut(Character character)
         {
+            ImmutableInterlocked.Update(ref characters, (c) => c.Remove(character));
+
             // Leave docking base channel on successful undocking.
             Transaction.Current.OnCommited(() => LeaveChannel(character));
         }
@@ -332,5 +337,11 @@ namespace Perpetuum.Units.DockingBases
 
             _centralBank.AddAmount(centralBankShare, transactionType);
         }
+
+        /// <summary>
+        /// All docked characters.
+        /// </summary>
+        private ImmutableHashSet<Character> characters = ImmutableHashSet<Character>.Empty;
+
     }
 }

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -170,6 +170,40 @@ namespace Perpetuum.Units.DockingBases
             Transaction.Current.OnCommited(() => JoinChannel(character));
         }
 
+        /// <summary>
+        /// Undock from docking base to zone.
+        /// </summary>
+        /// <param name="character">Character to undock</param>
+        /// <returns>Zone position for undocked character.</returns>
+        public Position? DockOut(Character character, ZoneEnterType type)
+        {
+            if (ZoneEnterType.Undock != type)
+            {
+                // Not enter to zone
+                return null;
+            }
+
+            DockOut(character);
+
+            // Update character status and position.
+            character.ZoneId = Zone.Id;
+            var position = UndockSpawnPositionSelector.SelectSpawnPosition(this);
+            character.ZonePosition = position;
+            character.IsDocked = false;
+            
+            return position; 
+        }
+
+        /// <summary>
+        /// Undock from docking base.
+        /// </summary>
+        /// <param name="character">Character to undock</param>
+        public void DockOut(Character character)
+        {
+            // Leave docking base channel on successful undocking.
+            Transaction.Current.OnCommited(() => LeaveChannel(character));
+        }
+
         protected IEnumerable<Character> GetCharacters()
         {
             return Db.Query().CommandText("select characterid from characters where baseeid=@eid and active=1")
@@ -250,12 +284,12 @@ namespace Perpetuum.Units.DockingBases
 
         protected virtual bool CanCreateEquippedStartRobot => Zone?.Configuration.Protected ?? false;
 
-        public virtual void JoinChannel(Character character)
+        protected virtual void JoinChannel(Character character)
         {
             ChannelManager.JoinChannel(ChannelName,character,ChannelMemberRole.Undefined,null);
         }
 
-        public void LeaveChannel(Character character)
+        protected void LeaveChannel(Character character)
         {
             ChannelManager.LeaveChannel(ChannelName,character);
         }

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -169,7 +169,7 @@ namespace Perpetuum.Units.DockingBases
             character.ZoneId = null;
             character.ZonePosition = null;
 
-            ImmutableInterlocked.Update(ref characters, (c) => c.Add(character));
+            ImmutableInterlocked.Update(ref docked, (c) => c.Add(character));
 
             if (ErrorCodes.NoError != IsDockingAllowed(character))
             {
@@ -210,7 +210,7 @@ namespace Perpetuum.Units.DockingBases
         /// <param name="character">Character to undock</param>
         public void DockOut(Character character)
         {
-            ImmutableInterlocked.Update(ref characters, (c) => c.Remove(character));
+            ImmutableInterlocked.Update(ref docked, (c) => c.Remove(character));
 
             // Leave docking base channel on successful undocking.
             Transaction.Current.OnCommited(() => LeaveChannel(character));
@@ -348,45 +348,52 @@ namespace Perpetuum.Units.DockingBases
         /// <summary>
         /// All docked characters.
         /// </summary>
-        private ImmutableHashSet<Character> characters = ImmutableHashSet<Character>.Empty;
+        private ImmutableHashSet<Character> docked = ImmutableHashSet<Character>.Empty;
 
         /// <summary>
         /// Performing check for docked characters.
         /// </summary>
         public void CheckDockedCharacters()
         {
-            if (!characters.Any())
+            if (!docked.Any())
             {
                 return;
             }
 
-            // Statistic
-            int chTotal = 0;
-            int chNormalLeave = 0;
-            int chNormalJoin = 0;
-            int chInvalid = 0;
+            // Total number of docked characters
+            int characters_total = 0;
+            // The number of characters removed from the channel upon check
+            int characters_leave = 0;
+            // The number of characters connected to the channel during the check
+            int characters_join = 0;
+            // Number of characters not docked or not online. (Must always be zero!)
+            int characters_invalid = 0;
 
             var channel = ChannelManager.GetChannelByName(ChannelName);
             var transaction = Transaction.Current;
 
-            foreach (Character c in characters)
+            // All characters in the docking base list are processed
+            foreach (Character character in docked)
             {
-                chTotal++;
+                characters_total++;
 
-                var isOnline = c.IsOnline;
-                var isDocked = c.IsDocked;
+                // All characters must be online and docked
+                var isOnline = character.IsOnline;
+                var isDocked = character.IsDocked;
 
                 if (!isOnline || !isDocked)
                 {
-                    chInvalid++;
-                    transaction.OnCommited(() => LeaveChannel(c));
+                    // Removed from the list and from the chat if the character is not docked.
+                    characters_invalid++;
+                    DockOut(character);
 
-                    Logger.Warning($"[DockingBase]{this} Character:{c} isOnline:{c.IsOnline} isDocked:{c.IsDocked} IsDockingAllowed:{IsDockingAllowed(c)}");
+                    Logger.Warning($"[DockingBase]{this} Character:{character} isOnline:{character.IsOnline} isDocked:{character.IsDocked} IsDockingAllowed:{IsDockingAllowed(character)}");
                     continue;
                 }
 
-                var isMember = channel.GetMember(c) != null;
-                var isAllowed = IsDockingAllowed(c) == ErrorCodes.NoError;
+                // These two statuses must be the same
+                var isMember = channel.GetMember(character) != null;
+                var isAllowed = IsDockingAllowed(character) == ErrorCodes.NoError;
 
                 if (isMember == isAllowed)
                 {
@@ -397,17 +404,17 @@ namespace Perpetuum.Units.DockingBases
                 if (isAllowed)
                 {
                     // ReJoin
-                    chNormalJoin++;
-                    transaction.OnCommited(() => JoinChannel(c));
+                    characters_join++;
+                    transaction.OnCommited(() => JoinChannel(character));
                     continue;
                 }
 
                 // Remove from channel
-                chNormalLeave++;
-                transaction.OnCommited(() => LeaveChannel(c));
+                characters_leave++;
+                transaction.OnCommited(() => LeaveChannel(character));
             }
             
-            Logger.Info($"[DockingBase]{this} total:{chTotal} leave:{chNormalLeave} join:{chNormalJoin} invalid:{chInvalid}");
+            Logger.Info($"[DockingBase]{this} total:{characters_total} leave:{characters_leave} join:{characters_join} invalid:{characters_invalid}");
         }
 
         /// <summary>

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -170,6 +170,11 @@ namespace Perpetuum.Units.DockingBases
 
             ImmutableInterlocked.Update(ref characters, (c) => c.Add(character));
 
+            if (ErrorCodes.NoError != IsDockingAllowed(character))
+            {
+                return;
+            }
+
             Transaction.Current.OnCommited(() => JoinChannel(character));
         }
 

--- a/src/Perpetuum/Units/DockingBases/DockingBase.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBase.cs
@@ -21,6 +21,7 @@ using Perpetuum.Zones;
 using Perpetuum.Zones.Intrusion;
 using Perpetuum.Zones.Training;
 using System.Collections.Immutable;
+using Perpetuum.Groups.Corporations;
 
 namespace Perpetuum.Units.DockingBases
 {
@@ -347,6 +348,16 @@ namespace Perpetuum.Units.DockingBases
         /// All docked characters.
         /// </summary>
         private ImmutableHashSet<Character> characters = ImmutableHashSet<Character>.Empty;
+
+        /// <summary>
+        /// Site owner
+        /// </summary>
+        /// <returns>Site owner as corporation</returns>
+        [CanBeNull]
+        public virtual Corporation GetSiteOwner()
+        {
+            return default;
+        }
 
     }
 }

--- a/src/Perpetuum/Units/DockingBases/DockingBaseHelper.cs
+++ b/src/Perpetuum/Units/DockingBases/DockingBaseHelper.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Perpetuum.Containers;
 using Perpetuum.EntityFramework;
 using Perpetuum.ExportedTypes;
+using Perpetuum.Groups.Corporations;
 using Perpetuum.Items.Helpers;
 using Perpetuum.Log;
 using Perpetuum.Services.ItemShop;
@@ -100,6 +101,22 @@ namespace Perpetuum.Units.DockingBases
 	    {
 	        return _zoneManager.Zones.GetUnits<DockingBase>()
 	            .Where(b => b.IsCategory(CategoryFlags.cf_public_docking_base));
+        }
+
+        /// <summary>
+        /// Get all corporation DockingBase
+        /// </summary>
+        /// <param name="corporation">Site owner</param>
+        /// <returns>All DockingBase for corporation</returns>
+        public IEnumerable<DockingBase> GetBySiteOwner(Corporation corporation)
+        {
+            if (corporation == null)
+            {
+                return new List<DockingBase>();
+            }
+
+            return _zoneManager.Zones.GetUnits<DockingBase>()
+                .Where(b => b.GetSiteOwner()?.Eid == corporation.Eid);
         }
 
         public Entity GetStationService(Entity serviceBase, EntityDefault serviceEntityDefault)

--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -1192,7 +1192,7 @@ namespace Perpetuum.Zones.Intrusion
         }
 
         [CanBeNull]
-        public Corporation GetSiteOwner()
+        public override Corporation GetSiteOwner()
         {
             var info = GetIntrusionSiteInfo();
             return Corporation.Get(info.Owner ?? 0L);

--- a/src/Perpetuum/Zones/Intrusion/Outpost.cs
+++ b/src/Perpetuum/Zones/Intrusion/Outpost.cs
@@ -575,6 +575,8 @@ namespace Perpetuum.Zones.Intrusion
                         //clear docking rights
                         SetDockingControlDetails(null, true);
                         InsertDockingRightsLog(null, null, siteInfo.Owner, IntrusionEvents.dockingRightsClearedByServer);
+                        //process docked characters
+                        CheckDockedCharacters();
                     }
                 }
 

--- a/src/Perpetuum/Zones/PBS/DockingBases/ExpiringPBSDockingBase.cs
+++ b/src/Perpetuum/Zones/PBS/DockingBases/ExpiringPBSDockingBase.cs
@@ -106,9 +106,10 @@ namespace Perpetuum.Zones.PBS.DockingBases
             base.OnUpdate(time);
         }
 
-        public override void JoinChannel(Character character)
+        protected override void JoinChannel(Character character)
         {
             base.JoinChannel(character);
+            // TODO: Announcement only to joined character
             ChannelManager.Announcement(ChannelName, _announcer, $"Base is going to expire in: {Remaining.ToHumanTimeString()}");
         }
 

--- a/src/Perpetuum/Zones/PBS/DockingBases/PBSDockingBase.cs
+++ b/src/Perpetuum/Zones/PBS/DockingBases/PBSDockingBase.cs
@@ -618,6 +618,12 @@ namespace Perpetuum.Zones.PBS.DockingBases
 
             return ec;
         }
+
+        [CanBeNull]
+        public override Corporation GetSiteOwner()
+        {
+            return Corporation.Get(Owner);
+        }
     }
 
 }


### PR DESCRIPTION
Blocks connection to terminal chat for characters who should not be able to dock. When relationships between corporations or access control change, characters are connected(disconnected) to(from) the chat in accordance with the new access level. Works for **all** docking bases.