### PR TITLE
Fix OpenPerpetuum/PerpetuumServer#342

### DIFF
--- a/src/Perpetuum/Zones/Movements/WaypointMovement.cs
+++ b/src/Perpetuum/Zones/Movements/WaypointMovement.cs
@@ -24,9 +24,22 @@ namespace Perpetuum.Zones.Movements
             unit.Direction = unit.CurrentPosition.DirectionTo(_target);
             unit.CurrentSpeed = 1.0;
 
-            _velocity = Vector2.Subtract(_target,unit.CurrentPosition.ToVector2());
-            _distance = Vector2.Abs(_velocity);
-            _velocity = Vector2.Normalize(_velocity);
+            // Vector to destination
+            var path = Vector2.Subtract(_target, unit.CurrentPosition.ToVector2());
+            // The absolute path along each coordinate
+            _distance = Vector2.Abs(path);
+            if (path.Length().IsApproximatelyEqual(0.0f))
+            {
+                // If the path is zero, then is already at the destination
+                Arrived = true;
+                // Velocity vector in the direction of the unit.
+                _velocity = MathHelper.DirectionToVector(unit.Direction);
+            }
+            else
+            {
+                // Velocity vector in the direction of the path.
+                _velocity = Vector2.Normalize(path);
+            }
 
             base.Start(unit);
         }


### PR DESCRIPTION
Fix - _"NPCs don't move"_ while aggro due to:
1. Normalization of **zero length** vector;
2. **Zeroing speed** and fail to find path to hostile;
3. Don't process **stationary** primary hostile.

No other reasons were found during testing.
