### PR TITLE
Additional effect from the use of paints (camouflage)

### DIFF
--- a/src/Perpetuum/GlobalConfiguration.cs
+++ b/src/Perpetuum/GlobalConfiguration.cs
@@ -38,5 +38,9 @@ namespace Perpetuum
         // Default EP value for new player.
         [DefaultValue(40000), JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public int StartEP { get; set; }
+
+        // Default camouflage bonus value for zone effect.
+        [DefaultValue(5), JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public int CamouflageBonus { get; set; }
     }
 }

--- a/src/Perpetuum/GlobalConfiguration.cs
+++ b/src/Perpetuum/GlobalConfiguration.cs
@@ -39,7 +39,7 @@ namespace Perpetuum
         [DefaultValue(40000), JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public int StartEP { get; set; }
 
-        // Default camouflage bonus value for zone effect.
+        // Default camouflage bonus value.
         [DefaultValue(5), JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public int CamouflageBonus { get; set; }
     }

--- a/src/Perpetuum/Players/Player.cs
+++ b/src/Perpetuum/Players/Player.cs
@@ -62,6 +62,7 @@ namespace Perpetuum.Players
         private readonly BlobHandler<Player> blobHandler;
         private readonly PlayerMovement movement;
         private readonly IntervalTimer combatTimer = new IntervalTimer(TimeSpan.FromSeconds(10));
+        private readonly GlobalConfiguration globalConfiguration;
         private CombatLogger combatLogger;
         private PlayerMoveCheckQueue check;
         private CancellableDespawnHelper despawnHelper;
@@ -121,7 +122,8 @@ namespace Perpetuum.Players
             MissionHandler.Factory missionHandlerFactory,
             ITeleportStrategyFactories teleportStrategyFactories,
             DockingBaseHelper dockingBaseHelper,
-            CombatLogger.Factory combatLoggerFactory)
+            CombatLogger.Factory combatLoggerFactory,
+            GlobalConfiguration globalConfiguration)
         {
             this.extensionReader = extensionReader;
             this.corporationManager = corporationManager;
@@ -129,6 +131,7 @@ namespace Perpetuum.Players
             this.teleportStrategyFactories = teleportStrategyFactories;
             this.dockingBaseHelper = dockingBaseHelper;
             this.combatLoggerFactory = combatLoggerFactory;
+            this.globalConfiguration = globalConfiguration;
             Session = ZoneSession.None;
             movement = new PlayerMovement(this);
 
@@ -1206,6 +1209,11 @@ namespace Perpetuum.Players
                     Logger.Exception(ex);
                 }
             }
+        }
+
+        protected override double CamouflageBonus()
+        {
+            return Math.Round(base.CamouflageBonus() * globalConfiguration.CamouflageBonus, 2);
         }
     }
 }

--- a/src/Perpetuum/Robots/Robot.cs
+++ b/src/Perpetuum/Robots/Robot.cs
@@ -373,5 +373,11 @@ namespace Perpetuum.Robots
             _modules = new Lazy<IEnumerable<Module>>(() => RobotComponents.SelectMany(c => c.Modules).ToArray());
             _activeModules = new Lazy<IEnumerable<ActiveModule>>(() => Modules.OfType<ActiveModule>().ToArray());
         }
+
+        protected override void OnEnterZone(IZone zone, ZoneEnterType enterType)
+        {
+            base.OnEnterZone(zone, enterType);
+            CamouflageUpdate();
+        }
     }
 }

--- a/src/Perpetuum/Units/Unit.cs
+++ b/src/Perpetuum/Units/Unit.cs
@@ -1014,7 +1014,7 @@ namespace Perpetuum.Units
 
         public double DetectionStrength => _detectionStrength.Value;
 
-        public double StealthStrength => _stealthStrength.Value;
+        public virtual double StealthStrength => _stealthStrength.Value;
 
         public double Massiveness => _massiveness.Value;
 


### PR DESCRIPTION
I propose adding an additional effect to the color of the robot - **camouflage**. Depending on the _color of the robot_ and the _faction of the island_, the strength of the camouflage changes. For balance, absolute values can be increased/decreased by the same factor. Below is a table for **standard paint** colors:

![image](https://github.com/OpenPerpetuum/PerpetuumServer/assets/101519462/f1fafc25-b1eb-4ac1-b32d-cceac5a3cd41)

