### PR TITLE
Industrial turrets

### DIFF
--- a/src/Perpetuum/Modules/DrillerModule.cs
+++ b/src/Perpetuum/Modules/DrillerModule.cs
@@ -120,27 +120,63 @@ namespace Perpetuum.Modules
             return rand <= chance ? 1 : 0;
         }
 
+        /// <summary>
+        /// Extracting materials.
+        /// </summary>
+        /// <param name="zone">The island on which the extraction takes place.</param>
         public void DoExtractMinerals(IZone zone)
         {
             TerrainLock terrainLock = GetLock().ThrowIfNotType<TerrainLock>(ErrorCodes.InvalidLockType);
 
-            MaterialType materialType;
-
+            // Material to be extracted
+            MaterialInfo materialInfo = default;
+            
             if (ParentRobot is RemoteControlledCreature)
             {
-                materialType = zone.Terrain.GetMaterialTypeAtPosition(terrainLock.Location);
+                // For remote modules we are looking for material with the maximum amount
+                uint maxAmount = 0;
+
+                // For all possible minerals on the island...
+                foreach (var layer in zone.Terrain.Materials.OfType<MineralLayer>())
+                {
+                    // Trying to get a deposit at the targeting point
+                    if (!layer.TryGetNode(terrainLock.Location, out MineralNode node))
+                        continue;
+
+                    // If the mineral is no more than what has already been found, then we skip it
+                    var amount = node.GetValue(terrainLock.Location);
+                    if (amount <= 0 || amount <= maxAmount)
+                    {
+                        continue;
+                    }
+
+                    // Remember the mineral for later extraction
+                    maxAmount = amount;
+                    materialInfo = _materialHelper.GetMaterialInfo(layer.Type);
+                }
+
+                // Nothing found ? Let's go out.
+                if (maxAmount <= 0)
+                {
+                    return;
+                }
             }
             else
             {
+                // The material is determined by the type of charge
                 if (!(GetAmmo() is MiningAmmo ammo))
                 {
                     return;
                 }
 
-                materialType = ammo.MaterialType;
+                materialInfo = _materialHelper.GetMaterialInfo(ammo.MaterialType);
             }
 
-            MaterialInfo materialInfo = _materialHelper.GetMaterialInfo(materialType);
+            if (materialInfo == default)
+            {
+                // There is nothing to extract.
+                return;
+            }
 
             CheckEnablerEffect(materialInfo);
 

--- a/src/Perpetuum/Zones/NpcSystem/AI/HarvestingIndustrialTurretAI.cs
+++ b/src/Perpetuum/Zones/NpcSystem/AI/HarvestingIndustrialTurretAI.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Perpetuum.Zones.NpcSystem.AI
 {
@@ -13,6 +15,8 @@ namespace Perpetuum.Zones.NpcSystem.AI
             base.Update(time);
         }
 
+        private int lookingForHarvestingTargets;
+
         public void FindIndustrialTargets(TimeSpan time)
         {
             UpdateFrequency.Update(time);
@@ -20,7 +24,15 @@ namespace Perpetuum.Zones.NpcSystem.AI
             if (UpdateFrequency.Passed)
             {
                 UpdateFrequency.Reset();
-                smartCreature.LookingForHarvestingTargets();
+                if (Interlocked.CompareExchange(ref lookingForHarvestingTargets, 1, 0) == 1)
+                {
+                    return;
+                }
+                Task.Run(smartCreature.LookingForHarvestingTargets)
+                    .ContinueWith((_) =>
+                    {
+                        Interlocked.Exchange(ref lookingForHarvestingTargets, 0);
+                    });
             }
         }
     }

--- a/src/Perpetuum/Zones/NpcSystem/AI/IndustrialAI.cs
+++ b/src/Perpetuum/Zones/NpcSystem/AI/IndustrialAI.cs
@@ -16,7 +16,7 @@ namespace Perpetuum.Zones.NpcSystem.AI
 {
     public class IndustrialAI : BaseAI
     {
-        private const int UpdateFrequency = 1650;
+        private const int UpdateFrequency = 5500;
         private const int EjectFrequency = 300000;
         private const double VolumeToEject = 10.0;
         private readonly IntervalTimer processIndustrialTargetsTimer = new IntervalTimer(UpdateFrequency);

--- a/src/Perpetuum/Zones/NpcSystem/AI/IndustrialAI.cs
+++ b/src/Perpetuum/Zones/NpcSystem/AI/IndustrialAI.cs
@@ -65,6 +65,7 @@ namespace Perpetuum.Zones.NpcSystem.AI
             if (processIndustrialTargetsTimer.Passed)
             {
                 processIndustrialTargetsTimer.Reset();
+                // TODO: Use Task.Run for this.
                 ProcessIndustrialTargets();
             }
         }
@@ -185,12 +186,12 @@ namespace Perpetuum.Zones.NpcSystem.AI
             {
                 var industrialTarget = industrialTargetsEnumerator.Current;
 
-                if (!this.smartCreature.IsInLockingRange(industrialTarget.Position))
+                if (this.smartCreature.IsInLockingRange(industrialTarget.Position))
                 {
-                    continue;
+                    // Use the first suitable target.
+                    SetLockForIndustrialTarget(industrialTarget);
+                    break;
                 }
-
-                SetLockForIndustrialTarget(industrialTarget);
             }
         }
 

--- a/src/Perpetuum/Zones/NpcSystem/AI/IndustrialAI.cs
+++ b/src/Perpetuum/Zones/NpcSystem/AI/IndustrialAI.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using Perpetuum.Zones.NpcSystem.IndustrialTargetsManagement;
 using Perpetuum.Zones.NpcSystem.AI.Behaviors;
 using Perpetuum.Zones.RemoteControl;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Perpetuum.Zones.NpcSystem.AI
 {
@@ -58,6 +60,8 @@ namespace Perpetuum.Zones.NpcSystem.AI
                 .Build();
         }
 
+        private int processIndustrialTargets;
+
         protected void UpdateIndustrialTargets(TimeSpan time)
         {
             processIndustrialTargetsTimer.Update(time);
@@ -65,8 +69,16 @@ namespace Perpetuum.Zones.NpcSystem.AI
             if (processIndustrialTargetsTimer.Passed)
             {
                 processIndustrialTargetsTimer.Reset();
-                // TODO: Use Task.Run for this.
-                ProcessIndustrialTargets();
+                
+                if (Interlocked.CompareExchange(ref processIndustrialTargets, 1, 0) == 1)
+                {
+                    return;
+                }
+                Task.Run(ProcessIndustrialTargets)
+                    .ContinueWith((_) =>
+                    {
+                        Interlocked.Exchange(ref processIndustrialTargets, 0);
+                    });
             }
         }
 

--- a/src/Perpetuum/Zones/NpcSystem/AI/MiningIndustrialTurretAI.cs
+++ b/src/Perpetuum/Zones/NpcSystem/AI/MiningIndustrialTurretAI.cs
@@ -20,6 +20,7 @@ namespace Perpetuum.Zones.NpcSystem.AI
             if (UpdateFrequency.Passed)
             {
                 UpdateFrequency.Reset();
+                // TODO: Use Task.Run for this.
                 smartCreature.LookingForMiningTargets();
             }
         }

--- a/src/Perpetuum/Zones/NpcSystem/AI/MiningIndustrialTurretAI.cs
+++ b/src/Perpetuum/Zones/NpcSystem/AI/MiningIndustrialTurretAI.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Perpetuum.Zones.NpcSystem.AI
 {
@@ -13,6 +15,8 @@ namespace Perpetuum.Zones.NpcSystem.AI
             base.Update(time);
         }
 
+        private int lookingForMiningTargets;
+
         public void FindIndustrialTargets(TimeSpan time)
         {
             UpdateFrequency.Update(time);
@@ -20,8 +24,15 @@ namespace Perpetuum.Zones.NpcSystem.AI
             if (UpdateFrequency.Passed)
             {
                 UpdateFrequency.Reset();
-                // TODO: Use Task.Run for this.
-                smartCreature.LookingForMiningTargets();
+                if (Interlocked.CompareExchange(ref lookingForMiningTargets, 1, 0) == 1)
+                {
+                    return;
+                }
+                Task.Run(smartCreature.LookingForMiningTargets)
+                    .ContinueWith((_) =>
+                    {
+                        Interlocked.Exchange(ref lookingForMiningTargets, 0);
+                    });
             }
         }
     }


### PR DESCRIPTION
Changes/fixes in the operation of industrial turrets. Initial fixes include:
- search for mineral extraction copied from single-tile scanner;
- use the first suitable target for mining;
- searching and processing targets occurs as a task;
- targets are processed less frequently (not faster than detection).

In the debug environment, 50 turrets work normally at the same time:

![image](https://github.com/OpenPerpetuum/PerpetuumServer/assets/101519462/9299f93d-2225-46f7-bf5c-6c98b684e159)
