### PR TITLE
Fixed gang creation in the zone

### DIFF
--- a/src/Perpetuum/Groups/Gangs/GangManager.cs
+++ b/src/Perpetuum/Groups/Gangs/GangManager.cs
@@ -56,11 +56,21 @@ namespace Perpetuum.Groups.Gangs
             gang.Id = Guid.NewGuid();
             gang.Name = gangName;
             gang.Leader = leader;
-            gang.SetMember(leader);
+            // In addition to leadership, an assistant role is also needed
+            // so that when the leader changes, the creator does not lose
+            // control over the gang
+            gang.SetMember(leader, GangRole.Assistant);
 
             _gangRepository.Insert(gang);
 
-            void Finish() => _channelManager.CreateAndJoinChannel(ChannelType.Gang, gang.ChannelName, gang.Leader);
+            void Finish()
+            {
+                // In addition to the DB repository, need to add a new gang to the dictionary
+                _gangs.Add(gang.Id, gang);
+                _channelManager.CreateAndJoinChannel(ChannelType.Gang, gang.ChannelName, gang.Leader);
+                // Perform actions upon completion of the gang creation
+                GangCreate?.Invoke(gang, leader);
+            }
 
             if (Transaction.Current != null)
                 Transaction.Current.OnCommited(Finish);
@@ -212,6 +222,7 @@ namespace Perpetuum.Groups.Gangs
                 Finish();
         }
 
+        public event Action<Gang, Character> GangCreate;
         public event Action<Gang,Character> GangMemberJoined;
         public event Action<Gang, Character> GangMemberRemoved;
 

--- a/src/Perpetuum/Groups/Gangs/IGangManager.cs
+++ b/src/Perpetuum/Groups/Gangs/IGangManager.cs
@@ -20,6 +20,11 @@ namespace Perpetuum.Groups.Gangs
         void ChangeLeader(Gang gang, Character newLeader);
         void SetRole(Gang gang, Character member, GangRole newRole);
 
+        /// <summary>
+        /// An action performed after a gang is created
+        /// </summary>
+        event Action<Gang,Character /* leader */> GangCreate;
+        
         event Action<Gang,Character /* member */> GangMemberJoined;
         event Action<Gang,Character /* member */> GangMemberRemoved;
         event Action<Gang> GangDisbanded;

--- a/src/Perpetuum/Zones/Zone.cs
+++ b/src/Perpetuum/Zones/Zone.cs
@@ -94,6 +94,7 @@ namespace Perpetuum.Zones
             IsLayerEditLocked = true;
             sessionManager.CharacterDeselected += OnCharacterDeselected;
             _gangManager = gangManager;
+            _gangManager.GangCreate += OnGangCreate;
             _gangManager.GangMemberJoined += OnGangMemberJoined;
             _gangManager.GangMemberRemoved += OnGangMemberRemoved;
             _gangManager.GangDisbanded += OnGangDisbanded;
@@ -128,6 +129,13 @@ namespace Perpetuum.Zones
             SaveUnitsToDb<PBSObject>();
             SaveUnitsToDb<ProximityDeviceBase>();
         }
+
+        /// <summary>
+        /// Perform the necessary actions for the zone after creating the gang.
+        /// </summary>
+        /// <param name="gang">Newly formed gang</param>
+        /// <param name="character">The creator of the gang</param>
+        private void OnGangCreate(Gang gang, Character character) => OnGangMemberJoined(gang, character);
 
         private void OnGangMemberJoined(Gang gang, Character character)
         {


### PR DESCRIPTION
When creating a squad on the surface, it doesn't work initially. The leader must log in and out of the base. The problem is that after creating the squad, the leader is left with an uninitialized **Gang** field. The patch contains a solution to this problem.