### PR TITLE
AOE tries to damage containers

### DIFF
--- a/src/Perpetuum/Units/Unit.cs
+++ b/src/Perpetuum/Units/Unit.cs
@@ -387,6 +387,8 @@ namespace Perpetuum.Units
 
         protected virtual void OnBeforeRemovedFromZone(IZone zone) { }
 
+        public bool CannotTakeDamage => _damageProcessor?.CannotTakeDamage ?? true;
+
         public void TakeDamage(DamageInfo damageInfo)
         {
             _damageProcessor.TakeDamage(damageInfo);

--- a/src/Perpetuum/Zones/DamageProcessors/DamageProcessor.cs
+++ b/src/Perpetuum/Zones/DamageProcessors/DamageProcessor.cs
@@ -44,9 +44,12 @@ namespace Perpetuum.Zones.DamageProcessors
             });
         }
 
+        public bool CannotTakeDamage =>
+            !unit.InZone || unit.IsAttackable != ErrorCodes.NoError || unit.States.Dead || unit.IsInvulnerable;
+
         public void TakeDamage(DamageInfo damageInfo)
         {
-            if (!unit.InZone || unit.IsAttackable != ErrorCodes.NoError || unit.States.Dead || unit.IsInvulnerable)
+            if (CannotTakeDamage)
             {
                 return;
             }
@@ -84,7 +87,7 @@ namespace Perpetuum.Zones.DamageProcessors
 
         private void ProcessDamage(DamageInfo damageInfo)
         {
-            if (!unit.InZone || unit.IsAttackable != ErrorCodes.NoError || unit.States.Dead || unit.IsInvulnerable)
+            if (CannotTakeDamage)
             {
                 return;
             }

--- a/src/Perpetuum/Zones/ZoneExtensions.cs
+++ b/src/Perpetuum/Zones/ZoneExtensions.cs
@@ -240,6 +240,11 @@ namespace Perpetuum.Zones
                     continue;
                 }
 
+                if (unit.CannotTakeDamage)
+                {
+                    continue;
+                }
+
                 LOSResult losResult = zone.IsInLineOfSight(damageInfo.attacker, unit, false);
                 if (losResult.hit)
                 {


### PR DESCRIPTION
LOS calculations are performed **before** damage calculations. When farming in zones other than Alpha, if an NPC explodes, LOS calculations are performed for **all containers** within the explosion radius. I recommend ignoring invulnerable units when calculating AOE damage to optimize performance.

![aoe2container](https://github.com/user-attachments/assets/2d68b208-cfde-4e64-8d83-92a5af63985f)
